### PR TITLE
Page on official training resources

### DIFF
--- a/content/guides/local-development-environment-configuration.md
+++ b/content/guides/local-development-environment-configuration.md
@@ -140,6 +140,7 @@ Run the following commands in the order:
 gcloud auth login
 gcloud auth application-default login
 gcloud auth configure-docker
+gcloud container clusters get-credentials spark-op-services --zone europe-west1-b --project spark-int-cloud-services
 ```
 
 Running the first couple commands, your browser will open, asking for authorization to access your account. If you have more than one Google/GMail account configured you'll have to explicitely choose the `sparkfabrik.com` one.

--- a/content/procedures/projects-environments-availability.md
+++ b/content/procedures/projects-environments-availability.md
@@ -3,7 +3,7 @@
 Our CI pipelines build a lot of different environments for each project every day.  
 Aside from branch-related pipelines built for automated testing purposes, we also have more stable environments like staging, demos or develop.
 
-Those environments live on a Kubernetes cluster (see [Access Kubernetes Sparkfabrik cluster](/guides/access-k8s-sparkfabrik-cluster)) which under load may scale well over 20 active nodes. To reduce costs **and** to enforce our policies on a healthy work/life balance, we leverage the dynamic nature of the cloud and scale the cluster down to 2 or 3 nodes after 8:00PM. At 8:00AM the environment are respawn transparently.  
+Those environments live on a Kubernetes cluster (see [Access Kubernetes Sparkfabrik cluster](/guides/local-development-environment-configuration#log-into-gcloud)) which under load may scale well over 20 active nodes. To reduce costs **and** to enforce our policies on a healthy work/life balance, we leverage the dynamic nature of the cloud and scale the cluster down to 2 or 3 nodes after 8:00PM. At 8:00AM the environment are respawn transparently.  
 Same happens during the weekends, so you're not supposed to visit a staging environment on sunday. We really hope you have something better to do!
 
 So, **if you try to connect to an environment during the _down phase_** and you get something like a _503 Bad gateway_ error, don't fire the alarm! As long as nobody of the operations team communicated scheduled or unscheduled maintenance activities, you environments will be up and running normally the next day.

--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -1,0 +1,79 @@
+SparkFabrik offers access to a set of training resources.
+
+Some of them are _self service_ and can be accessed by every employee as they see fit. Some others are licences on a per-seat basis and requires the creation of a personal account and relative license.
+
+This page lists all the available resources, providing a link to them and a mean to obtain access, when required.
+
+At the bottom of this page, in the [Training requests](#training-requests) section, we explain how to submit requests for specific training courses and keep an eye on new training resources that SparkFabrik may make available to everyone.
+
+## Training resources
+
+### Udemy
+
+We have a Udemy account we use to buy development courses that may be necessary to improve our skills or build them from zero.  
+Mainly you can find training on frameworks and technologies (also Cloud technologies) of common use in SparkFabrik (Angular, React, AWS and others), but also on more specific tools.
+
+Given the wide offering of topics on Udemy, more courses can be added in the future, even in non technical topics.
+
+> [Head to Udemy](https://www.udemy.com/join/login-popup/), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
+> 
+> ```bash
+> ..... the command ..... @TODO
+> ```
+
+### Ultimate Courses
+
+On Ultimate Courses, you can access a set of very thoroghful and deep courses on Angular by Todd Motto. Those courses are very good for who wants to deepen his understanding of Angular, get the hang of it's internals and learning how to use NgRx (a reactive state management library).
+
+> [Head to Ultimate Courses](https://app.ultimatecourses.com), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
+> 
+> ```bash
+> ..... the command ..... @TODO
+> ```
+
+### Drupalize.me
+
+On Drupalize.me you can build up a strong understanting on Drupal CMS, following extensive training paths that will guide you from the basics to the more advenced topics.
+
+Those resources are available to PHP developers who needs to understand how Drupal works as well as to Drupal developers who need to dig deeper into specific parts of the framework.
+
+> [Head to Drupalize.me](https://drupalize.me), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
+> 
+> ```bash
+> ..... the command ..... @TODO
+> ```
+
+### AWS Skillbuilder
+
+As AWS Partners, SparkFabrik has free access to a huge amount of training material on Amazon's Cloud offering and services, through their _Skillbuilder_ portal.
+
+Those resources are great if you and your team want to leverage AWS services in the project at hand.
+
+> [Head to AWS Skillbuilder](https://explore.skillbuilder.aws), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
+> 
+> ```bash
+> ..... the command ..... @TODO
+> ```
+
+### Google SkillBoost
+
+As GCP Partners, SparkFabrik has free access to a huge amount of training material on Google Cloud Platform's offering and services, through their _Skill Boost_ portal.
+
+Those resources are great if you and your team want to leverage AWS services in the project at hand.
+
+> [Head to GCP Skill Boost](https://partners.cloudskillsboost.google), then just login with your _sparkfabrik.com_ account.
+
+### Cloud Academy
+
+Cloud Academy offers a complete environment to train for many Certifications Exams, from vendor-specific ones to CNCF certifications program like KCA/CKAD.
+
+The platform offers video-courses, training sandboxes, guided labs and exam simulations.
+There is no self-service access to Cloud Academy platform: SparkFabrik has a specific number of seats that can be assigned depending on the Certified Training Program we put in place twice a year.
+
+If you want to discuss a Certified Training on Cloud topics, please let us know filing a request as described below.
+
+## Training requests
+
+SparkFabrik employees can file a request for specific training.
+
+...

--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -19,7 +19,6 @@ Please find here a TOC of the available training resources.
 | [Google SkillBoost](#google-skillboost) | Cloud | Google Cloud Platform | Corporate account |
 | [Cloud Academy](#cloud-academy) | Cloud | Vendor-specific services (AWS, GCP, Azure, Alibaba), Kubernetes, complete Cloud training offering | Reserved seats |
 
-
 ### Development
 
 #### Udemy
@@ -29,20 +28,22 @@ Mainly you can find training on frameworks and technologies (also Cloud technolo
 
 Given the wide offering of topics on Udemy, more courses can be added in the future, even in non technical topics.
 
-> Head to [Udemy](https://www.udemy.com/join/login-popup/), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
+> 1. Make sure you are [logged into GCloud](/guides/local-development-environment-configuration#log-into-gcloud) with your SparkFabrik account.  
+> 2. Head to [Udemy](https://www.udemy.com/join/login-popup/), then obtain access credentials issuing this command into a terminal:
 > 
 > ```bash
-> ..... the command ..... @TODO
+> gcloud secrets versions access "latest" --secret credentials-udemy --project sf-public-ring
 > ```
 
 #### Ultimate Courses
 
 On Ultimate Courses, you can access a set of very thoroghful and deep courses on Angular by Todd Motto. Those courses are very good for who wants to deepen his understanding of Angular, get the hang of it's internals and learning how to use NgRx (a reactive state management library).
 
-> Head to [Ultimate Courses](https://app.ultimatecourses.com), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
+> 1. Make sure you are [logged into GCloud](/guides/local-development-environment-configuration#log-into-gcloud) with your SparkFabrik account.  
+> 2. Head to [Ultimate Courses](https://app.ultimatecourses.com), then obtain access credentials issuing this command into a terminal:
 > 
 > ```bash
-> ..... the command ..... @TODO
+> gcloud secrets versions access "latest" --secret credentials-ultimate-courses --project sf-public-ring
 > ```
 
 #### Drupalize.me
@@ -51,10 +52,11 @@ On Drupalize.me you can build up a strong understanting on Drupal CMS, following
 
 Those resources are available to PHP developers who needs to understand how Drupal works as well as to Drupal developers who need to dig deeper into specific parts of the framework.
 
-> Head to [Drupalize.me](https://drupalize.me), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
+> 1. Make sure you are [logged into GCloud](/guides/local-development-environment-configuration#log-into-gcloud) with your SparkFabrik account.  
+> 2. Head to [Drupalize.me](https://drupalize.me), then obtain access credentials issuing this command into a terminal:
 > 
 > ```bash
-> ..... the command ..... @TODO
+> gcloud secrets versions access "latest" --secret credentials-drupalize-me --project sf-public-ring
 > ```
 
 ### Cloud
@@ -74,6 +76,11 @@ As GCP Partners, SparkFabrik has free access to a huge amount of training materi
 Those resources are great if you and your team want to leverage AWS services in the project at hand.
 
 > Head to [GCP Skill Boost](https://partners.cloudskillsboost.google), then access using your `sparkfabrik.com` account.
+
+With Google SkillBoost comes **Qwiklabs**, a real cloud environments that help developers and IT professionals learn cloud platforms and software, such as Firebase, Kubernetes and more.
+
+> To access **QwikLabs** you just have to fill in [a registration form](https://partner.cloudskillsboost.google/course_sessions/1257385/video/187468
+) using your `sparkfabrik.com' account.
 
 
 #### Cloud Academy

--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -4,76 +4,99 @@ Some of them are _self service_ and can be accessed by every employee as they se
 
 This page lists all the available resources, providing a link to them and a mean to obtain access, when required.
 
-At the bottom of this page, in the [Training requests](#training-requests) section, we explain how to submit requests for specific training courses and keep an eye on new training resources that SparkFabrik may make available to everyone.
+At the bottom of this page, in the [Filing training requests](#filing-training-requests) section, we explain how to submit requests for specific training courses/resources and keep an eye on new training resources that SparkFabrik may make available to everyone.
 
 ## Training resources
 
-### Udemy
+Please find here a TOC of the available training resources.
+
+| Name | Area | Topics | Access type |
+|---|---|---|---|
+| [Udemy](#udemy)| Development | Angular, React, React Native, Hasura | Credentials |
+| [Ultimate Courses](#ultimate-courses) | Development | Angular, React, Typescript | Credentials |
+| [Drupalize.me](#drupalizeme) | Development | Drupal | Credentials |
+| [AWS SkillBuilder](#aws-skillbuilder) | Cloud | Amazon Web Services | Corporate account |
+| [Google SkillBoost](#google-skillboost) | Cloud | Google Cloud Platform | Corporate account |
+| [Cloud Academy](#cloud-academy) | Cloud | Vendor-specific services (AWS, GCP, Azure, Alibaba), Kubernetes, complete Cloud training offering | Reserved seats |
+
+
+### Development
+
+#### Udemy
 
 We have a Udemy account we use to buy development courses that may be necessary to improve our skills or build them from zero.  
 Mainly you can find training on frameworks and technologies (also Cloud technologies) of common use in SparkFabrik (Angular, React, AWS and others), but also on more specific tools.
 
 Given the wide offering of topics on Udemy, more courses can be added in the future, even in non technical topics.
 
-> [Head to Udemy](https://www.udemy.com/join/login-popup/), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
+> Head to [Udemy](https://www.udemy.com/join/login-popup/), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
 > 
 > ```bash
 > ..... the command ..... @TODO
 > ```
 
-### Ultimate Courses
+#### Ultimate Courses
 
 On Ultimate Courses, you can access a set of very thoroghful and deep courses on Angular by Todd Motto. Those courses are very good for who wants to deepen his understanding of Angular, get the hang of it's internals and learning how to use NgRx (a reactive state management library).
 
-> [Head to Ultimate Courses](https://app.ultimatecourses.com), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
+> Head to [Ultimate Courses](https://app.ultimatecourses.com), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
 > 
 > ```bash
 > ..... the command ..... @TODO
 > ```
 
-### Drupalize.me
+#### Drupalize.me
 
 On Drupalize.me you can build up a strong understanting on Drupal CMS, following extensive training paths that will guide you from the basics to the more advenced topics.
 
 Those resources are available to PHP developers who needs to understand how Drupal works as well as to Drupal developers who need to dig deeper into specific parts of the framework.
 
-> [Head to Drupalize.me](https://drupalize.me), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
+> Head to [Drupalize.me](https://drupalize.me), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
 > 
 > ```bash
 > ..... the command ..... @TODO
 > ```
 
-### AWS Skillbuilder
+### Cloud
+
+#### AWS Skillbuilder
 
 As AWS Partners, SparkFabrik has free access to a huge amount of training material on Amazon's Cloud offering and services, through their _Skillbuilder_ portal.
 
 Those resources are great if you and your team want to leverage AWS services in the project at hand.
 
-> [Head to AWS Skillbuilder](https://explore.skillbuilder.aws), then obtain access credentials through your SparkFabrik account, issuing this command into a terminal:
-> 
-> ```bash
-> ..... the command ..... @TODO
-> ```
+> Head to [AWS Skillbuilder](https://explore.skillbuilder.aws), then access using your `sparkfabrik.com` account.
 
-### Google SkillBoost
+#### Google SkillBoost
 
 As GCP Partners, SparkFabrik has free access to a huge amount of training material on Google Cloud Platform's offering and services, through their _Skill Boost_ portal.
 
 Those resources are great if you and your team want to leverage AWS services in the project at hand.
 
-> [Head to GCP Skill Boost](https://partners.cloudskillsboost.google), then just login with your _sparkfabrik.com_ account.
+> Head to [GCP Skill Boost](https://partners.cloudskillsboost.google), then access using your `sparkfabrik.com` account.
 
-### Cloud Academy
+
+#### Cloud Academy
 
 Cloud Academy offers a complete environment to train for many Certifications Exams, from vendor-specific ones to CNCF certifications program like KCA/CKAD.
 
 The platform offers video-courses, training sandboxes, guided labs and exam simulations.
+
 There is no self-service access to Cloud Academy platform: SparkFabrik has a specific number of seats that can be assigned depending on the Certified Training Program we put in place twice a year.
 
 If you want to discuss a Certified Training on Cloud topics, please let us know filing a request as described below.
 
-## Training requests
+> Head to [Cloud Academy](https://cloudacademy.com/), then access using your `sparkfabrik.com` account. **You need to have a valid, active seat to access the training material**.
 
-SparkFabrik employees can file a request for specific training.
+## Filing training requests
 
-...
+SparkFabrik employees can file a request for specific training resources, by filling in [this _Training Request_ form](https://forms.gle/D3sMame93iJ6avxX7).
+
+The requests will be evaluated by the management taking into account may factors, among which:
+
+* The available training budget
+* The relevance and impact on your professional position/growth
+* The alignment with corporate strategy
+* Your training track record (if any)
+
+To speed up the evaluation process, please make sure to provide detailed information, following each field's suggestion.


### PR DESCRIPTION
This page contains a list of all the sources of training material SparkFabrik offers to its employees, alongside instructions to access them.

It also adds a section on how to file a new training resource request by filling in a form (much like the confererence attendee request form).
