### PR TITLE
feat: replaces DNSDOCK_ALIAS with VIRTUAL_HOST

### DIFF
--- a/content/guides/local-development-environment-configuration.md
+++ b/content/guides/local-development-environment-configuration.md
@@ -173,7 +173,7 @@ To test that everything is working as expected, we'll try to run a service in a 
 #### Dinghy HTTP proxy
 
 ```bash
-❯ docker run -d -e DNSDOCK_ALIAS=test.sparkfabrik.loc nginx:alpine
+❯ docker run -d -e VIRTUAL_HOST=test.sparkfabrik.loc nginx:alpine
 
 ❯ curl test.sparkfabrik.loc | grep -i nginx
 


### PR DESCRIPTION
In the _Test and enjoy -> Dinghy HTTP proxy_ paragraph I replaced the environment variable because the test (as written) does not work for mac.