### PR TITLE
163 fix broken links

### DIFF
--- a/content/organization/roles-accountabilities.md
+++ b/content/organization/roles-accountabilities.md
@@ -10,7 +10,7 @@ We all share a set of accountabilities, regardless of our job position and role 
 
 ### Client satisfaction
 
-The client is not always right, or they would not turn to us to solve their problems. Still, [we value technical quality and good human relations over everything else](https://www.sparkfabrik.com/en/who-we-are.html). Be kind and clear, explain your positions and always focus on customer needs, with open ears and a bright smile. Everybody is called to ultimately deliver a great customer experience.
+The client is not always right, or they would not turn to us to solve their problems. Still, [we value technical quality and good human relations over everything else](https://www.sparkfabrik.com/en/the-manifesto/). Be kind and clear, explain your positions and always focus on customer needs, with open ears and a bright smile. Everybody is called to ultimately deliver a great customer experience.
 
 ### Delivering projects
 

--- a/content/procedures/employee-onboarding.md
+++ b/content/procedures/employee-onboarding.md
@@ -57,8 +57,8 @@ The employee must, with the help of an HR representative:
 * Generate an SSH key and add it among the available keys for their Gitlab account
 * Access all relevant calendars
 * Set their profile pictures (starting with Gravatar and checking on Gitlab, Slack, Toggl, etc) with an appropriate close-up
-* Set their e-mail signature in [the official format](#Standard-mail-signature-format) (respect bolds)
-* Set the [SparkFabrik branded LinkedIn banner](#LinkedIn-brand-guidelines) on the Linkedin profile
+* Set their e-mail signature in [the official format](#standard-mail-signature-format) (respect bolds)
+* Set the [SparkFabrik branded LinkedIn banner](#branded-linkedin-banner) on the Linkedin profile
 
 ### Company overview
 

--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -29,7 +29,7 @@ Mainly you can find training on frameworks and technologies (also Cloud technolo
 Given the wide offering of topics on Udemy, more courses can be added in the future, even in non-technical topics.
 
 > 1. Make sure you are [logged into GCloud](/guides/local-development-environment-configuration#log-into-gcloud) with your SparkFabrik account.  
-> 2. Head to [Udemy](https://www.udemy.com/join/login-popup/), then obtain access credentials issuing this command into a terminal:
+> 2. Head to [Udemy](https://www.udemy.com/) login page, then obtain access credentials issuing this command into a terminal:
 > 
 > ```bash
 > gcloud secrets versions access "latest" --secret credentials-udemy --project sf-public-ring

--- a/content/tools-and-policies/access-to-the-office-during-covid19-pandemic.md
+++ b/content/tools-and-policies/access-to-the-office-during-covid19-pandemic.md
@@ -14,7 +14,7 @@ Limitations also apply to accessing the meeting rooms and common areas.
 
 To book access to the office, write to <office-booking@sparkfabrik.com> and wait for a confirmation email.
 
-To know who's in the office, take a look at this calendar [Presenze in ufficio](https://calendar.google.com/calendar/u/1/embed?src=agavee.com_1eaeflfo4q9siffm4bj6umkpuk@group.calendar.google.com&ctz=Europe/Rome) or add [this ical](https://calendar.google.com/calendar/ical/agavee.com_1eaeflfo4q9siffm4bj6umkpuk%40group.calendar.google.com/private-999297412c557aade34f6654b5e2b923/basic.ics) to your calendar tool.
+To know who's in the office, take a look at this calendar [Presenze in ufficio](https://calendar.google.com/calendar/u/1/embed?src=agavee.com_1eaeflfo4q9siffm4bj6umkpuk@group.calendar.google.com&ctz=Europe/Rome) and add it to your calendar tool (you can use the bottom right button).
 
 ## Accessing the office
 

--- a/content/tools-and-policies/communication-channels-and-register.md
+++ b/content/tools-and-policies/communication-channels-and-register.md
@@ -5,7 +5,7 @@ Sort: 10
 
 ## Communication channels
 
-    @todo refer to the [Management](/tools-and-policies/management page), relevant subsections
+    @todo refer to the [Management page](/tools-and-policies/management), relevant subsections
 
 ## Communication register
 

--- a/content/tools-and-policies/frontend-guidelines-drupal8.md
+++ b/content/tools-and-policies/frontend-guidelines-drupal8.md
@@ -13,7 +13,7 @@ Sort: 100
 - [CSS: architecture and guidelines](#css-architecture-and-guidelines)
   - [CSS architecture](#css-architecture)
     - [Principles](#principles)
-    - [Best practices](#best-practices)
+    - [Best practices](#best-practices-for-css)
       - [Avoid reliance on HTML structure](#avoid-reliance-on-html-structure)
       - [Define component elements (sub-objects) using their own classes](#define-component-elements-sub-objects-using-their-own-classes)
       - [Extend components using modifier classes.](#extend-components-using-modifier-classes)
@@ -25,7 +25,7 @@ Sort: 100
     - [File structure](#file-structure)
   - [CSS formatting guidelines](#css-formatting-guidelines)
 - [Javascript](#javascript)
-  - [Best practices](#best-practices-1)
+  - [Best practices](#best-practices-for-js)
   - [JavaScript and JQuery formatting guidelines](#javascript-and-jquery-formatting-guidelines)
 
 ## Purpose of this document
@@ -63,7 +63,7 @@ The goals of good CSS should be:
 * Maintainable: As new components and features are needed, it should be easy to add, modify and extend CSS without breaking (or refactoring) existing styles.
 * Scalable: CSS should be easy to manage for a single developer or large, distributed teams.
 
-#### Best practices
+#### Best practices for CSS
 
 ##### Avoid reliance on HTML structure
 
@@ -233,7 +233,7 @@ To learn more look at official community documentation:
 
 * [https://www.drupal.org/docs/develop/standards/javascript](https://www.drupal.org/docs/develop/standards/javascript)
 
-### Best practices
+### Best practices for JS
 
 * **JavaScript code SHOULD NOT be embedded in the HTML** where possible, as it adds significantly to page weight with no opportunity for mitigation by caching and compression.
 * **Code SHOULD use literal expressions instead of the new operator**:

--- a/content/working-at-sparkfabrik/career-advancement.md
+++ b/content/working-at-sparkfabrik/career-advancement.md
@@ -27,7 +27,7 @@ Taking a new role will impact:
 
 ## Taking the challenge
 
-To fulfill [its vision](https://www.sparkfabrik.com/en/who-we-are.html), SparkFabrik sells and cultivates high seniorities. We generally expect junior developers to eventually become senior developers.
+To fulfill [its vision](https://www.sparkfabrik.com/en/the-manifesto/), SparkFabrik sells and cultivates high seniorities. We generally expect junior developers to eventually become senior developers.
 
 Still, despite nobody can consciously avoid learning from experience, not all juniors want to take over the responsibilities of a senior. And not all seniors crave to become team leaders or software architects. This is understandable and we respect the choice.  
 

--- a/content/working-at-sparkfabrik/career-advancement.md
+++ b/content/working-at-sparkfabrik/career-advancement.md
@@ -7,7 +7,7 @@ People in SparkFabrik should expect to advance on their career path, depending o
 
 ## Checkpoints
 
-Each developer can assess their overall level of proficiency by their [impact assessment](/working-at-sparkfabrik/impact-assessment), a qualitative measure of the expected positive outcome of our work<sup>[1](#fn1)</sup>.
+Each developer can assess their overall level of proficiency by their [impact assessment](/working-at-sparkfabrik/impact-assessment), a qualitative measure of the expected positive outcome of our work<sup><a href="#fn1">1</a></sup>.
 
 Stepping up on your career path will then be based on adherence to values and the actual impact you make, not on personal perception of your merit.  
 Each developer role model has its impact assessment card.

--- a/content/working-at-sparkfabrik/hiring-from-abroad.md
+++ b/content/working-at-sparkfabrik/hiring-from-abroad.md
@@ -88,7 +88,7 @@ Different cultures bring different takes on work relations to the table. Plus re
 
 This is not the case: fiscal arrangement does not imply a temporary or loose releationship. Remote foreign workers are still considered SparkFabrik employees and have the same privileges and duties as each other colleagues.
 
-Given that, we invite remote foreign applicants to take a look at our take on [personal projects and work](/working-at-sparkfabrik/personal-projects.mdpersonal-projects).
+Given that, we invite remote foreign applicants to take a look at our take on [personal projects and work](/working-at-sparkfabrik/personal-projects).
 
 ### Language barrier
 

--- a/content/working-at-sparkfabrik/impact-assessment.md
+++ b/content/working-at-sparkfabrik/impact-assessment.md
@@ -63,4 +63,4 @@ Having to explain your reasons may help you be more objective. Should the conver
 
 ---
 
-<small><a name="fn1">1</a>: Our model has been inspired by [Deeson's one](https://handbook.deeson.co.uk/working-at-deeson/impact-assessment/), which in turn is claimed to be borrowed from [Stack Overflow](https://stackoverflow.com/company/salary/skills/web-developer?e=1&l=1) in the first place. Credits go to both companies for the great catch on evaluating substance and not numbers. Thank you guys!</small>
+<small><a name="fn1">1</a>: Our model has been inspired by [Deeson's one](https://handbook.deeson.co.uk/personal-development/impact-scoring), which in turn is claimed to be borrowed from [Stack Overflow](https://stackoverflow.co/company/careers/) in the first place. Credits go to both companies for the great catch on evaluating substance and not numbers. Thank you guys!</small>


### PR DESCRIPTION
Using an enhanced version of `markdown-link-validator` (see #167) not yet released, I highlighted and fixed some broken links in markdown pages.