### PR TITLE
167 exp link checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ cli:
 logs:
 	docker-compose logs -f
 
+check:
+	npx --yes markdown-link-validator ./content
+
 # Sparkkit based themes specific commands.
 theme-watch:
 	chmod +x bin/npm

--- a/content/FAQ/can-i-have.md
+++ b/content/FAQ/can-i-have.md
@@ -3,7 +3,7 @@
 Yes. We have budgets for Linux PCs, Apple machines, PHPStorm licenses and some more gizmos that you may need.
 
 Other than that, if you need a device or license to speed up your work, just ask your team leader and we'll evaluate case by case.
-On standard hardware and software, please read [this section](/tools-and-policies/approved-hardware-and-software) to learn more.
+On standard hardware and software, please read [this section](../tools-and-policies/approved-hardware-and-software.md) to learn more.
 
 ### Books
 
@@ -27,7 +27,7 @@ Of course, if you suffer real disease, we'll do our best to acknowledge you all 
 
 ### Tickets for a conference
 
-We always love to stay in the _consphere_, [here you can find](/tools-and-policies/attending-conferences) our policies.
+We always love to stay in the _consphere_, [here you can find](../tools-and-policies/attending-conferences.md) our policies.
 
 ### A training course
 

--- a/content/guides/an-effective-onboarding-structure.md
+++ b/content/guides/an-effective-onboarding-structure.md
@@ -9,7 +9,7 @@ As with every process, onboarding has inputs and outputs.
 Inputs are the involved people and a set of clear goals.  
 The output is a new teammate who can autonomously find their way within the company, providing valuable work and participating in the whole team life, with little to no friction.
 
-There are prerequisites, of course. To make sure nothing is missing, it suffices to follow [this handy checklist](/procedures/employee-onboarding).
+There are prerequisites, of course. To make sure nothing is missing, it suffices to follow [this handy checklist](../procedures/employee-onboarding.md).
 
 Once they are fulfilled, the next step is to set the goals and schedule check-ups.
 

--- a/content/guides/an-introduction-to-docker.md
+++ b/content/guides/an-introduction-to-docker.md
@@ -3,7 +3,7 @@ This tutorial contains examples to become familiar with _docker_'s basics.
 ## Requirements
 
 Well, you must have docker up and running on your PC.  
-Follow the guide at [Configure local environment](/guides/local-development-environment-configuration) if you are still out of luck.
+Follow the guide at [Configure local environment](local-development-environment-configuration.md) if you are still out of luck.
 
 > **NOTE**: Mind that if you are on macOS, you must make sure that the `DOCKER_MACHINE_IP` environment variable is configured on your host system
 
@@ -543,7 +543,7 @@ With docker-compose this is a breeze. What we basically did was:
 
 Thus all apps will have their own local infrastructure, you can start it with a single command and only when needed. The only persistent (i.e. `--restart=always`) container on the local machine is the dnsdock one.
 
-> To learn all you need on our local environment read our [Local Environment setup guide](/guides/local-development-environment-configuration).
+> To learn all you need on our local environment read our [Local Environment setup guide](../guides/local-development-environment-configuration.md).
 
 
 ### macOS Resolver's issues

--- a/content/guides/contributing-to-tech-blog.md
+++ b/content/guides/contributing-to-tech-blog.md
@@ -169,7 +169,7 @@ We are using the typical GitHub contribution flow, based on pull requests, so:
 
 Deploy occurs automatically on PR merge, so sit back and enjoy fame.
 
-**NOTE**: a quick checklist is available [as a procedure](/procedures/tech-blog-contributions-checklist) page.
+**NOTE**: a quick checklist is available [as a procedure](../procedures/tech-blog-contributions-checklist.md) page.
 
 ## External contributions
 

--- a/content/organization/administration.md
+++ b/content/organization/administration.md
@@ -5,11 +5,11 @@ Sort: 15
 
 ## Administration owners
 
-Administration in SparkFabrik is carried out mainly by members of the [Executive Board](/organization/governance) with the help of [Supporters](/organization/role-isc-supporter) - employees owning one or more processes and procedures vital to the health of the company.
+Administration in SparkFabrik is carried out mainly by members of the [Executive Board](../organization/governance.md) with the help of [Supporters](../organization/role-isc-supporter.md) - employees owning one or more processes and procedures vital to the health of the company.
 
 Despite not being directly involved in the core business or value delivery, Supporters are **the glue that holds governance and operations together**, thus being an essential gear in the company machinery.  
 They are facilitators, assistants, secretaries, organizers and the ultimate source of truth about so much information necessary for managers to properly hold the steering wheel.
 
-The [Supporter role](/organization/role-isc-supporter) has its [impact assessment card](/working-at-sparkfabrik/impact-assessment) and, if not for the nature of its duties, is subject to the same requirements and quality standards as the other [operational roles](/organization/operations).
+The [Supporter role](../organization/role-isc-supporter.md) has its [impact assessment card](../working-at-sparkfabrik/impact-assessment.md) and, if not for the nature of its duties, is subject to the same requirements and quality standards as the other [operational roles](../organization/operations.md).
 
-In addition to supporters, [Lead developers](/organization/role-isc-lead-developer) and [Professionals](/organization/role-isc-professional) are often involved in administrative processes like reporting, project budgeting, lead assessment and so on.
+In addition to supporters, [Lead developers](../organization/role-isc-lead-developer.md) and [Professionals](../organization/role-isc-professional.md) are often involved in administrative processes like reporting, project budgeting, lead assessment and so on.

--- a/content/organization/operations.md
+++ b/content/organization/operations.md
@@ -12,14 +12,14 @@ Operational career paths expand vertically (_Growth_) and horizontally (_Special
 
 ### Growth
 
-We recognize four levels of professional skills, depending on seniority and level of proficiency. Each level has its salary bracket, mission and clear expectations. Developers [progress over this career path](/working-at-sparkfabrik/career-advancement.md) by their length of service, their results and by nurturing their technical and non-technical skills.
+We recognize four levels of professional skills, depending on seniority and level of proficiency. Each level has its salary bracket, mission and clear expectations. Developers [progress over this career path](../working-at-sparkfabrik/career-advancement.md) by their length of service, their results and by nurturing their technical and non-technical skills.
 
 * **Junior developer**: this is the level where duly graduated people or developers already experienced in other technologies start. We expect people to quickly step up to the next level, ideally in 12 to 36 months of employment.
 * **Senior developer**: this is the level that composes the big part of our company and that we heavily rely upon. People at this level are skilled and proficient with both our technology and our methodology. They can mentor juniors and are autonomous in their work.
 * **Lead developer**: those are the people that lead teams and projects in SparkFabrik. Those people have a senior-level background on top of which they developed the soft skills necessary to govern the social, technical and organizational complexity of our work.
 * **Professional**: this is the highest operational role in SparkFabrik. Professionals are the people that embody a speciality, can work with one or multiple teams at once, represent SparkFabrik at important tables, provide training and mentorships, etc. Professionals may occasionally lead a team, but they are supposed to work cross-teams as reference key people.
 
-Learn more about each [role accountabilities](/organization/roles-accountabilities).
+Learn more about each [role accountabilities](../organization/roles-accountabilities.md).
 
 ### Specialities
 
@@ -32,4 +32,4 @@ We explained that SparkFabrik only employs _developers_. Sure there are differen
 
 ## How to advance
 
-We track and rule [people career advancement](/working-at-sparkfabrik/career-advancement.md) to make it fair and clear to everybody.
+We track and rule [people career advancement](../working-at-sparkfabrik/career-advancement.md) to make it fair and clear to everybody.

--- a/content/organization/roles-accountabilities.md
+++ b/content/organization/roles-accountabilities.md
@@ -34,10 +34,10 @@ Operational roles are described in terms of **impact assessment cards**: documen
 
 As you take on new roles and possibly even move between specialties (we love multi-talented people), your specific accountabilities will be described by one (or more) assessment cards.
 
-* [Junior developer](/resources/role-iac-junior-developer)
-* [Senior developer](/resources/role-iac-senior-developer)
-* [Lead developer](/resources/role-iac-lead-developer)
-* [Professional](/resources/role-iac-professional)
-* [Supporter](/resources/role-iac-supporter)
+* [Junior developer](../resources/role-iac-junior-developer.md)
+* [Senior developer](../resources/role-iac-senior-developer.md)
+* [Lead developer](../resources/role-iac-lead-developer.md)
+* [Professional](../resources/role-iac-professional.md)
+* [Supporter](../resources/role-iac-supporter.md)
 
 Printing ICSs directly from the browser will result in a version properly formatted to sit together and tick single scores. Try it out!

--- a/content/procedures/employee-onboarding.md
+++ b/content/procedures/employee-onboarding.md
@@ -52,13 +52,13 @@ An HR representative will perform the following actions:
 The employee must, with the help of an HR representative:
 
 * Duly sign in and check their ability to access every service
-* If they are a developer, log into GCP using [this procedure](/guides/local-development-environment-configuration#log-into-gcloud)
+* If they are a developer, log into GCP using [this procedure](../guides/local-development-environment-configuration.md#log-into-gcloud)
 * Activate two-factor authentication on Gitlab
 * Generate an SSH key and add it among the available keys for their Gitlab account
 * Access all relevant calendars
 * Set their profile pictures (starting with Gravatar and checking on Gitlab, Slack, Toggl, etc) with an appropriate close-up
-* Set their e-mail signature in [the official format](#Standard-mail-signature-format) (respect bolds)
-* Set the [SparkFabrik branded LinkedIn banner](#LinkedIn-brand-guidelines) on the Linkedin profile
+* Set their e-mail signature in [the official format](#standard-mail-signature-format) (respect bolds)
+* Set the [SparkFabrik branded LinkedIn banner](#branded-linkedin-banner) on the Linkedin profile
 
 ### Company overview
 
@@ -96,7 +96,7 @@ The Team Leader will also make sure that:
 
 * The buddy reviews the core-skills list with the colleague and a training plan is laid out on the topics that need upskilling
 * HR and the employee will schedule a 30 mins self-introduction to the whole company
-* HR will schedule a 1-on-1 meeting with the employee at the end of the second week, to check in on the [onboarding goals](/guides/an-effective-onboarding-structure)
+* HR will schedule a 1-on-1 meeting with the employee at the end of the second week, to check in on the [onboarding goals](../guides/an-effective-onboarding-structure.md)
 * The Team Leader will schedule a 1-on-1 meeting with the employee at the end of the first month, to exchange feedback and set the goals for the next couple months
 * Marketing will contact the employee to choose a face wall shot (this can be used as a profile picture as well)
 

--- a/content/procedures/projects-environments-availability.md
+++ b/content/procedures/projects-environments-availability.md
@@ -3,7 +3,7 @@
 Our CI pipelines build a lot of different environments for each project every day.  
 Aside from branch-related pipelines built for automated testing purposes, we also have more stable environments like `staging`, `demos` or `develop`.
 
-Those environments live on a Kubernetes cluster (see [Access Kubernetes SparkFabrik cluster](/guides/local-development-environment-configuration#log-into-gcloud)) which under load may scale well over 20 active nodes. To reduce costs **and** to enforce our policies on a healthy work/life balance, we leverage the dynamic nature of the cloud and scale the cluster down to 2 or 3 nodes after 8:00 PM. At 8:00 AM the environment respawns transparently.  
+Those environments live on a Kubernetes cluster (see [Access Kubernetes SparkFabrik cluster](../guides/local-development-environment-configuration.md#log-into-gcloud)) which under load may scale well over 20 active nodes. To reduce costs **and** to enforce our policies on a healthy work/life balance, we leverage the dynamic nature of the cloud and scale the cluster down to 2 or 3 nodes after 8:00 PM. At 8:00 AM the environment respawns transparently.  
 The same happens during the weekends, so you're not supposed to visit a staging environment on Sunday. We hope you got something better to do!
 
 So, **if you try to connect to an environment during the _down phase_** and you get something like a _503 Bad gateway_ error, don't fire the alarm! As long as nobody on the operations team communicated scheduled or unscheduled maintenance activities, your environments will be up and running normally the next day.

--- a/content/procedures/tech-blog-contributions-checklist.md
+++ b/content/procedures/tech-blog-contributions-checklist.md
@@ -1,6 +1,6 @@
 ## Checklist for technical blog contributions
 
-For a complete introduction to tech blog contributions see [Contributing to Tech Blog](/guides/contributing-to-tech-blog).
+For a complete introduction to tech blog contributions see [Contributing to Tech Blog](../guides/contributing-to-tech-blog.md).
 
 Here follows a quick checklist to make sure you don't miss anything.
 

--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -28,7 +28,7 @@ Mainly you can find training on frameworks and technologies (also Cloud technolo
 
 Given the wide offering of topics on Udemy, more courses can be added in the future, even in non-technical topics.
 
-> 1. Make sure you are [logged into GCloud](/guides/local-development-environment-configuration#log-into-gcloud) with your SparkFabrik account.  
+> 1. Make sure you are [logged into GCloud](../guides/local-development-environment-configuration.md#log-into-gcloud) with your SparkFabrik account.  
 > 2. Head to [Udemy](https://www.udemy.com/join/login-popup/), then obtain access credentials issuing this command into a terminal:
 > 
 > ```bash
@@ -39,7 +39,7 @@ Given the wide offering of topics on Udemy, more courses can be added in the fut
 
 On Ultimate Courses, you can access a set of very thorough and deep courses on Angular by Todd Motto. Those courses are very good for those who want to deepen their understanding of Angular, get the hang of its internals and learn how to use NgRx (a reactive state management library).
 
-> 1. Make sure you are [logged into GCloud](/guides/local-development-environment-configuration#log-into-gcloud) with your SparkFabrik account.  
+> 1. Make sure you are [logged into GCloud](../guides/local-development-environment-configuration.md#log-into-gcloud) with your SparkFabrik account.  
 > 2. Head to [Ultimate Courses](https://app.ultimatecourses.com), then obtain access credentials issuing this command into a terminal:
 > 
 > ```bash
@@ -52,7 +52,7 @@ On Drupalize.me you can build up a strong understanding of Drupal CMS, following
 
 Those resources are available to PHP developers who need to understand how Drupal works as well as to Drupal developers who need to dig deeper into specific parts of the framework.
 
-> 1. Make sure you are [logged into GCloud](/guides/local-development-environment-configuration#log-into-gcloud) with your SparkFabrik account.  
+> 1. Make sure you are [logged into GCloud](../guides/local-development-environment-configuration.md#log-into-gcloud) with your SparkFabrik account.  
 > 2. Head to [Drupalize.me](https://drupalize.me), then obtain access credentials issuing this command into a terminal:
 > 
 > ```bash

--- a/content/tools-and-policies/communication-channels-and-register.md
+++ b/content/tools-and-policies/communication-channels-and-register.md
@@ -5,7 +5,7 @@ Sort: 10
 
 ## Communication channels
 
-    @todo refer to the [Management](/tools-and-policies/management page), relevant subsections
+    @todo refer to the [Management](../tools-and-policies/management.md) page, relevant subsections
 
 ## Communication register
 

--- a/content/tools-and-policies/gitlab-board-workflow.md
+++ b/content/tools-and-policies/gitlab-board-workflow.md
@@ -16,7 +16,7 @@ Sort: 110
 
 Each project has its peculiarities, but you can start from the following suggestions, inspired by Kanban methodology, on how to set up your board for visualization, readability and clarity.
 
-Before we start, consider starting from our [templates](/tools-and-policies/gitlab-issue-templates) when you write your issues. A well-organized board with poor requirements is pretty useless, after all.
+Before we start, consider starting from our [templates](../tools-and-policies/gitlab-issue-templates.md) when you write your issues. A well-organized board with poor requirements is pretty useless, after all.
 
 ## Board columns
 
@@ -33,7 +33,7 @@ It's a good idea to tell issues which requirements are complete enough to be tak
 1. **To do:** When a team plans a new iteration, they move the cards from the `Open` column in `To Do`. This represents the team's commitment.  
 Each team member can then pull tasks from `To Do`, moving them to the `Doing` column, either choosing the ones that are assigned to them or choosing from the unassigned ones.
 
-1. **Doing:** This column represents the work-in-progress. We don't want this column to grow too large, since too much WIP is detrimental to the delivery flow. When an issue is done (see our [Universal Definition of Done (UDoD)](/tools-and-policies/universal-dod)), the assignee can move it to the next column.
+1. **Doing:** This column represents the work-in-progress. We don't want this column to grow too large, since too much WIP is detrimental to the delivery flow. When an issue is done (see our [Universal Definition of Done (UDoD)](../tools-and-policies/universal-dod.md)), the assignee can move it to the next column.
 
 1. **Closed:** This column is where all completed tasks are placed. Once a task has been completed and reviewed - and usually merged and deployed to the production environment - it can be moved to this column.
 
@@ -58,7 +58,7 @@ Here we provide the most common cases we use labels for. Labels may be configure
 
 ### Issue type
 
-1. **Bug:** This label is used to mark issues that seem to be or are in fact bugs. It's typically used when a piece of functionality isn't working as expected and needs to be fixed. If it applies, please reference the original feature issue in a bug issue and make sure the description contains a list of steps to reproduce the bug, the expected behavior and the observed behavior (refer to our [templates](/tools-and-policies/gitlab-issue-templates) for a good starting point).
+1. **Bug:** This label is used to mark issues that seem to be or are in fact bugs. It's typically used when a piece of functionality isn't working as expected and needs to be fixed. If it applies, please reference the original feature issue in a bug issue and make sure the description contains a list of steps to reproduce the bug, the expected behavior and the observed behavior (refer to our [templates](../tools-and-policies/gitlab-issue-templates.md) for a good starting point).
 
 1. **CR** or **Change Request:** This label is used to mark maintenance activities. It's typically used when a change needs to be made to an existing feature or functionality, instead of adding a new one. If the customer has access to the board and files bugs report directly to the project backlog, some bugs may requalify as CRs when analyzed.
 

--- a/content/tools-and-policies/universal-dod.md
+++ b/content/tools-and-policies/universal-dod.md
@@ -17,7 +17,7 @@ All this helps us to **shape a better product**, reducing the cognitive load nee
 
 ### What's a Definition of Done?
 
-According to the [_Scrum Alliance_ definition]((https://resources.scrumalliance.org/Article/definition-dod)):
+According to the [_Scrum Alliance_ definition](https://resources.scrumalliance.org/Article/definition-dod):
 
 > _"Definition of done is a simple list of activities (writing code, coding comments, unit testing, integration testing, release notes, design documents, etc.) that add verifiable/demonstrable value to the product. Focusing on value-added steps allows the team to focus on what must be completed in order to build software while eliminating wasteful activities that only complicate software growth efforts."_
 

--- a/content/working-at-sparkfabrik/career-advancement.md
+++ b/content/working-at-sparkfabrik/career-advancement.md
@@ -7,7 +7,7 @@ People in SparkFabrik should expect to advance on their career path, depending o
 
 ## Checkpoints
 
-Each developer can assess their overall level of proficiency by their [impact assessment](/working-at-sparkfabrik/impact-assessment), a qualitative measure of the expected positive outcome of our work<sup>[1](#fn1)</sup>.
+Each developer can assess their overall level of proficiency by their [impact assessment](../working-at-sparkfabrik/impact-assessment.md), a qualitative measure of the expected positive outcome of our work<sup>[1](#fn1)</sup>.
 
 Stepping up on your career path will then be based on adherence to values and the actual impact you make, not on personal perception of your merit.  
 Each developer role model has its impact assessment card.
@@ -23,7 +23,7 @@ Ask for a meeting with your manager or an HR representative to set your goals an
 Taking a new role will impact:
 
 * your salary according to the baselines for that role (may change over time);
-* your duties following your new [impact assessment card](/organization/roles-accountabilities#per-role-accountabilities).
+* your duties following your new [impact assessment card](../organization/roles-accountabilities.md#per-role-accountabilities).
 
 ## Taking the challenge
 
@@ -36,7 +36,7 @@ We will help you understand the new role's benefits, expectations and duties. It
 
 We encourage everybody to take the challenge and we may even probe people who already refused if we see a new opportunity for them to shine, but we can't push or force any advancement.
 
-Still, we expect **every developer** to constantly increase their assessment and set new professional goals, maybe tackling new [Specialities](/organization/operations#specialities) in their career, making side steps instead of climbing a ladder.
+Still, we expect **every developer** to constantly increase their assessment and set new professional goals, maybe tackling new [Specialities](../organization/operations.md#specialities) in their career, making side steps instead of climbing a ladder.
 
 ---
 

--- a/content/working-at-sparkfabrik/hiring-from-abroad.md
+++ b/content/working-at-sparkfabrik/hiring-from-abroad.md
@@ -12,7 +12,7 @@ The main difference lies in the type of contract we sign with the new employee.
 
 ## Relocating foreign workers
 
-Relocating to Italy will require effort and paperwork (we have a [guide to relocation](/guides/relocating-to-italy) that explains the process in detail) but will allow SparkFabrik to grant you a _Collective Labour Agreement_ (CLA).
+Relocating to Italy will require effort and paperwork (we have a [guide to relocation](../guides/relocating-to-italy.md) that explains the process in detail) but will allow SparkFabrik to grant you a _Collective Labour Agreement_ (CLA).
 
 Depending on where you come from, you may or may not have to ask for a visa. European citizens may come to Italy and be hired freely, as they were Italian citizens. People from other countries will require a working or family visa.
 
@@ -88,7 +88,7 @@ Different cultures bring different takes on work relations to the table. Plus re
 
 This is not the case: fiscal arrangement does not imply a temporary or loose releationship. Remote foreign workers are still considered SparkFabrik employees and have the same privileges and duties as each other colleagues.
 
-Given that, we invite remote foreign applicants to take a look at our take on [personal projects and work](/working-at-sparkfabrik/personal-projects.mdpersonal-projects).
+Given that, we invite remote foreign applicants to take a look at our take on [personal projects and work](../working-at-sparkfabrik/personal-projects.md).
 
 ### Language barrier
 

--- a/content/working-at-sparkfabrik/impact-assessment.md
+++ b/content/working-at-sparkfabrik/impact-assessment.md
@@ -13,9 +13,9 @@ Each of us has different ambitions and expectations for our careers. With impact
 
 Instead of putting numbers or quantitative goals on our heads, we evaluate our employees based on the impact they must have on the company's business<sup><a href="#fn1">1</a></sup>. The duties of each role are detailed based on the desired outcome, not as a set of tasks and procedures to put in place.
 
-These outcomes are seen as important to business, context and company culture by the [company governance](/organization/governance) and each of us is called to put his creativity, wit and experience to good use so that we can reach our goals together.
+These outcomes are seen as important to business, context and company culture by the [company governance](../organization/governance.md) and each of us is called to put his creativity, wit and experience to good use so that we can reach our goals together.
 
-Each role has its [impact assessment card](/organization/roles-accountabilities#per-role-accountabilities), which lists all expected impacts and qualities that the role is expected to have.
+Each role has its [impact assessment card](../organization/roles-accountabilities.md#per-role-accountabilities), which lists all expected impacts and qualities that the role is expected to have.
 
 For each point in the impact assessment card, you can mark out one of three possible values:
 
@@ -30,10 +30,10 @@ If you can't say or are confused, that's a sign you'd better talk to your respon
 You can print an IAC every time you feel like it and go with a self-assessment. Because, why not?  
 Of course, there are moments when this is most valuable:
 
-* When you feel lost about your [role and duties](/organization/roles-accountabilities) and want to check in on them to focus on what's important
-* When you think you are ready for a [step up in your career](/working-at-sparkfabrik/career-advancement), so you can take your self-assessment to the management so you can talk about your perceived strengths and weaknesses
+* When you feel lost about your [role and duties](../organization/roles-accountabilities.md) and want to check in on them to focus on what's important
+* When you think you are ready for a [step up in your career](../working-at-sparkfabrik/career-advancement.md), so you can take your self-assessment to the management so you can talk about your perceived strengths and weaknesses
 * When you ask for a raise, so you can sustain your request with a list of your positive impacts
-* Before one of the [one-to-one meeting](/working-at-sparkfabrik/one-to-one-meetings) scheduled by the company
+* Before one of the [one-to-one meeting](../working-at-sparkfabrik/one-to-one-meetings.md) scheduled by the company
 
 ## Self-assessment vs normal assessment
 

--- a/content/working-at-sparkfabrik/one-to-one-meetings.md
+++ b/content/working-at-sparkfabrik/one-to-one-meetings.md
@@ -14,7 +14,7 @@ The time is always right for a one-to-one, should the need arise. Anyone who wan
 As a rule of thumb, the company will make sure that every employee has at least two one-to-one meetings each year. All employees with a role in operations will attend the meeting with a designated HR representative.  
 There are no prerequisites for one-to-ones, and an effective agenda for the meeting is detailed below, but each employee who wants to take the most out of the event must come prepared with topics to discuss.
 
-The one-to-one is a great opportunity to talk about your career, your performance and your professional goals. If you feel this is important, we strongly advise you [get ready for the meeting with a self-assessment](/working-at-sparkfabrik/impact-assessment).  
+The one-to-one is a great opportunity to talk about your career, your performance and your professional goals. If you feel this is important, we strongly advise you [get ready for the meeting with a self-assessment](../working-at-sparkfabrik/impact-assessment.md).  
 Optionally you can ask for an assessment from your responsible or senior teammate - this is especially recommended for junior developers.
 
 ## Goal

--- a/content/working-at-sparkfabrik/referral-bounty.md
+++ b/content/working-at-sparkfabrik/referral-bounty.md
@@ -16,7 +16,7 @@ If you know anyone who you think is a good fit for a role we are searching for, 
 
 * Keep an eye on our [open positions](https://careers.sparkfabrik.com/en/#open-positions)
 * If you know someone who's a good fit for one of the positions, talk to them and head them to the relevant application form (mind to ask them to specify your name as a referral in the presentation letter)
-* The candidate will undergo the normal [selection process](/working-at-sparkfabrik/job-interviews)
+* The candidate will undergo the normal [selection process](../working-at-sparkfabrik/job-interviews.md)
 * If we actually hire the applicant and if they pass the probation period, you'll be rewarded a € 1K bonus
 
 ## Conditions


### PR DESCRIPTION
Simple addition of [markdown-link-validator](https://github.com/webhintio/markdown-link-validator) to Makefile using npx and some fixes to markdown files because of compatibility issues with original validator (ie. it not supports absolute local path `/path/to/local/file.md` or local path without `.md` extension, see #167).

> WARNING: you can find the enhanced version of markdown-link-validator on my [forked repo](https://github.com/jenkin/markdown-link-validator/tree/feature/sparkfabrik-enhancements). All fixes merged in #170 come from that enhanced version. **Fixes included in this draft PR should be rejected.**