### PR TITLE
#183 Core skills page

### DIFF
--- a/content/procedures/assessing-core-skills.md
+++ b/content/procedures/assessing-core-skills.md
@@ -90,7 +90,7 @@ Software Developers should have a basic understanding of:
 * **Basic commands**: pull, push, run, stop, ls, rm, ps, prune
 * **Docker-Compose**: 
   * Understanding declarative approach
-  * Anatomy of the `docker-compose.yml` file (services, build, volumes, ports, etc)
+  * Anatomy of the `docker-compose.yml` file (services, build, volumes, ports, environment variables interpolation, etc)
   * Basic commands (up, down, logs) and detachment
 
 Senior Software Developers and Cloud Native Engineers should be confident with the above, plus having a more specific understanding of:

--- a/content/procedures/assessing-core-skills.md
+++ b/content/procedures/assessing-core-skills.md
@@ -1,0 +1,90 @@
+During the onboarding of a new employee, a buddy or team leader is called to assess the new entry's proficiency level with a set of technical skills that apply to all technical projects.
+
+The required level of proficiency vary depending on the seniority and job position, but a minimum degree of literacy is required, as explained [here](/working-at-sparkfabrik/core-skills).
+
+To ease the process, we hereby provide guidelines for each [core skill](/working-at-sparkfabrik/core-skills) set.
+
+## Command line / Shell
+
+### Basics
+
+Software Developers should have a basic understanding of:
+
+* Files and folder management:
+  * **Navigation**: `ls`, `cd`, glob patterns
+  * **Search**: `find`, `which`
+  * **File management**: `cat`, `less`/`more`, `head`/`tail`, `touch`
+  * **Permissions**: `chmod` and `chown`, permissions sets, file attributes
+* **Shell configuration**: `.profile`/`.zprofile`, ``.bashrc`/`.zshrc`, environment variables, path and command scope, etc
+* **Redirection**: `stdout`, `stderr`, reading, writing, overwriting, appending to streams
+* **Make/Makefile**: targets, dependencies, recipes, rules
+
+Senior Software Developers and Cloud Native Engineers should be confident with the above, plus having a decent understanding of:
+
+* **Scripting**: Variables, arguments, cycles, conditions, functions, echoing
+* **Text processing**: `grep`, `sed`, `awk`
+
+### Networking
+
+Software Developers should have a basic understanding of:
+
+* Interfaces and ports, what's `localhost`, how domain names resolution works, HTTP basics, how HTTPS works.
+
+Senior Software Developers and Cloud Native Engineers should have a clear understanding about:
+
+* TCP/UDP-IP protocol, the concept of application-level protocols, DNS configuration basics (authoritative zone, record types, TTL and propagation), local domains resolution.
+
+
+### Security
+
+Software Developers should have a basic understanding of:
+
+* Asymmetric cryptography, SSH, authentication, signatures
+* Best-practices for secrets-management in software repo (environment variables and `.env` files, `.gitignore`, `.dockerignore`)
+* Security monitoring tools: CVE, GitHub advisory database, Dependabot / Renovate
+
+Senior Software Developers and Cloud Native Engineers should have a clear understanding about:
+
+* GPG, difference between authentication and authorization, OAuth framework, hashing
+* Best-practices for the development of secure software
+
+### Git
+
+Everyone should have a basic understanding of:
+
+* **Basic usage**: status, staging, commit, tag, reset, history / log, branch, remotes, merge, rebase, cherry picking, push, pull
+* **Concepts**: what's a repository, the working tree, the `.gitignore` file, how to diff and move along the commit history
+* **Workflow**: different branching models (git-flow, GitHub or Gitlab flow), pull/merge request, peer review, squashing commits, rebase and merge, merge commits, linear history
+* **Conventions**: understand the relation between workflow-related conventions (commit granularity, versioning, commit messages format, branching model, etc) and the working context (social contracts, environments, cadences, etc)
+
+
+## DevOps
+
+### Docker and docker-compose
+
+* **Concepts**: Docker daemon and client, images, tags, digest, containers, volumes, registries and DockerHub
+
+* **Basic commands**: pull, push, run, stop, ls, rm, ps, prune
+* **Dockerfiles**: levels, caching, basic commands (FROM, COPY, ADD, RUN, ENTRYPOINT, CMD, ENV, ARG), multi stage builds
+* **Docker-Compose**: 
+  * Understanding declarative approach
+  * Anatomy of the `docker-compose.yml` file (services, build, volumes, ports, etc)
+  * How networking and hostname resolution works between docker-composed containers
+  * Basic commands (up, down, logs) and detachment
+
+### Kubernetes
+
+* **Concepts**: multi-services architectures, orchestration, telemetry and monitoring, 12-Factors applications
+* **Building blocks**: clusters, nodes, deployments, pods, services, storage, networking
+
+### YAML
+
+* Basic knowledge of the use-cases and syntax
+* Knowledge of features like comments or references
+
+## Continuous Integration / Continuous Delivery
+
+* **Concepts**: what does integration and deploy mean, what does continuously integrating means and why it's important, the relation between integration and tests
+* **Building blocks**: Git, remotes, the different types of tests (unit, integration, functional, end-to-end), builds, deploys
+* **Common environments**: `development` (integration), `stage`, and `production`
+* **Delivery automation**: GitLab Pipelines and GitHub Actions

--- a/content/procedures/assessing-core-skills.md
+++ b/content/procedures/assessing-core-skills.md
@@ -134,7 +134,7 @@ If the emerging plan adds up to more than 40 hours, consider the following prior
 
 ### Schedule the effort
 
-There are several variables that can influence the schedule for study hours, like expertise, background, or learning speed of the new entry, project deadlines, needs, and organization, customer-related constraints, etc.  
+There are several variables that can influence the schedule for study hours, like expertise, background, or learning speed of the new entry, project deadlines, needs, organization, customer-related constraints, etc.  
 Therefore, each team-leader is free to decide how to plan the training with the new employee, as long as it's done within the first two months.
 
 For example, imagining that the training path takes up all 40 hours, they can decide to spend 10 consecutive afternoons for the first ten working days. Or they may want to seize some slack the project may grant for the first week to go all-in and spend it all learning the basics.  

--- a/content/procedures/assessing-core-skills.md
+++ b/content/procedures/assessing-core-skills.md
@@ -7,7 +7,7 @@ To ease the process, the [list of core skills](/working-at-sparkfabrik/core-skil
 The procedure is easy:
 
 * Use the guidelines and checklists below to assess the necessary skill level.
-* If the degree of confidence is low (most of the checklist elements are unknown or uncertain), the whole module is worth studying from scratch. If most of the topics are known and just a few ancillary are missing (ex. the assessee never used `sed` and `awk` but for the rest she's confident with a Unix shell), than the module may be skipped.
+* If the degree of confidence is low (most of the checklist elements are unknown or uncertain), the whole module is worth studying from scratch. If most of the topics are known and just a few ancillary are missing (e.g. the assessee never used `sed` and `awk` but for the rest, she's confident with a Unix shell), then the module may be skipped.
 * Take a list of the modules that have to be studied.
 * Head to the [Plan the training on Core Skills](#plan-the-training-on-core-skills) section below to schedule the training.
 
@@ -30,7 +30,7 @@ Software Developers should have a basic understanding of:
 * **Redirection**: `stdout`, `stderr`, reading, writing, overwriting, appending to streams
 * **Make/Makefile**: targets, dependencies, recipes, rules
 
-Senior Software Developers and Cloud Native Engineers should be confident with the above, plus having a decent understanding of:
+Senior Software Developers and Cloud Native Engineers should be confident with the above, plus have a decent understanding of:
 
 * **Scripting**: Variables, arguments, cycles, conditions, functions, echoing
 * **Text processing**: `grep`, `sed`, `awk`
@@ -40,23 +40,23 @@ Senior Software Developers and Cloud Native Engineers should be confident with t
 Software Developers should have a basic understanding of:
 
 * Asymmetric cryptography, SSH, authentication, signatures
-* Best-practices for secrets-management in software repo (environment variables and `.env` files, `.gitignore`, `.dockerignore`)
+* Best practices for secrets management in software repo (environment variables and `.env` files, `.gitignore`, `.dockerignore`)
 * Security monitoring tools: CVE, GitHub advisory database, Dependabot / Renovate
 
 Senior Software Developers and Cloud Native Engineers should have a clear understanding about:
 
-* GPG, difference between authentication and authorization, OAuth framework, hashing
-* Best-practices for the development of secure software
+* GPG, the difference between authentication and authorization, OAuth framework, hashing
+* Best practices for the development of secure software
 
 #### Networking
 
 Software Developers should have a basic understanding of:
 
-* Interfaces and ports, what's `localhost`, how domain names resolution works, HTTP basics, how HTTPS works.
+* Interfaces and ports, what's `localhost`, how domain name resolution works, HTTP basics, how HTTPS works.
 
 Senior Software Developers and Cloud Native Engineers should have a clear understanding about:
 
-* TCP/UDP-IP protocol, the concept of application-level protocols, DNS configuration basics (authoritative zone, record types, TTL and propagation), local domains resolution.
+* How the network stack works, the different levels of protocols, DNS configuration basics (authoritative zone, record types, TTL, and propagation), local domains resolution.
 
 ### Tools
 
@@ -64,21 +64,21 @@ Senior Software Developers and Cloud Native Engineers should have a clear unders
 
 Everyone should have a basic understanding of:
 
-* Basic knowledge of the use-cases and syntax
+* Basic knowledge of the use cases and syntax
 * Knowledge of features like comments or references
 
 #### Git
 
 Everyone should have a basic understanding of:
 
-* **Basic usage**: status, staging, commit, tag, reset, history / log, branch, remotes, merge, rebase, cherry picking, push, pull
+* **Basic usage**: status, staging, commit, tag, reset, history/log, branch, remotes, merge, rebase, cherry-picking, push, pull
 * **Concepts**: what's a repository, the working tree, the `.gitignore` file, how to diff and move along the commit history
 * **Workflow**: different branching models (git-flow, GitHub or GitLab flow), pull/merge request, peer review, squashing commits, rebase and merge, merge commits, linear history
-* **Conventions**: understand the relation between workflow-related conventions (commit granularity, versioning, commit messages format, branching model, etc) and the working context (social contracts, environments, cadences, etc)
+* **Conventions**: understand the relation between workflow-related conventions (commit granularity, versioning, commit messages format, branching model, etc.) and the working context (social contracts, environments, cadences, etc.)
 
 #### GitHub Copilot
 
-That's a "bonus track". Developers are the most impacted by the usage of Copilot, so just ask if they know what it is and if they every tried it.
+That's a "bonus track". Developers are the most impacted by the usage of Copilot, so just ask if they know what it is and if they ever tried it.
 
 ### DevOps
 
@@ -86,18 +86,18 @@ That's a "bonus track". Developers are the most impacted by the usage of Copilot
 
 Software Developers should have a basic understanding of:
 
-* **Concepts**: Docker daemon and client, general anatomy of a Dockerfile, images, tags, digest, containers, volumes, registries, and what is DockerHub
+* **Concepts**: Docker daemon and client, general anatomy of a Dockerfile, images, tags, digest, containers, volumes, container registries, and what is DockerHub
 * **Basic commands**: pull, push, run, stop, ls, rm, ps, prune
 * **Docker-Compose**: 
   * Understanding declarative approach
-  * Anatomy of the `docker-compose.yml` file (services, build, volumes, ports, environment variables interpolation, etc)
+  * Anatomy of the `docker-compose.yml` file (services, build, volumes, ports, environment variables interpolation, etc.)
   * Basic commands (up, down, logs) and detachment
 
-Senior Software Developers and Cloud Native Engineers should be confident with the above, plus having a more specific understanding of:
+Senior Software Developers and Cloud Native Engineers should be confident with the above, plus have a more specific understanding of:
 
-* **Dockerfiles**: levels, caching, basic commands (FROM, COPY, ADD, RUN, ENTRYPOINT, CMD, ENV, ARG), multi stage and multi arch builds
+* **Dockerfiles**: levels, caching, basic commands (FROM, COPY, ADD, RUN, ENTRYPOINT, CMD, ENV, ARG), multi-stage and multi-arch builds
 * **Docker-Compose**: 
-  * How networking and hostname resolution works between docker-composed containers
+  * How networking and hostname resolution work between docker-composed containers
 
 #### Kubernetes
 
@@ -110,7 +110,7 @@ Everyone should have a basic understanding of:
 
 Everyone should have a basic understanding of:
 
-* **Concepts**: what does integration and deploy mean, what does continuously integrating means and why it's important, the relation between integration and tests
+* **Concepts**: what does integration and deployment mean, what does continuously integrating mean and why it's important, the relation between integration and tests
 * **Building blocks**: Git, remotes, the different types of tests (unit, integration, functional, end-to-end), builds, deploys
 * **Common environments**: `development` (integration), `stage`, and `production`
 * **Delivery automation**: GitLab Pipelines and GitHub Actions
@@ -119,12 +119,12 @@ Everyone should have a basic understanding of:
 
 ### Laying out contents
 
-Depending on the findings of the assessment phase (described above), **a maximum of 40 working hours** will be allocated **within the first two two months** for the new employee to learn the key-concepts.
+Depending on the findings of the assessment phase (described above), **a maximum of 40 working hours** will be allocated **within the first two months** for the new employee to learn the key concepts.
 
 
-To layout and schedule the plan, the [Core Skills training resources](/resources/training-resources#core-skills-training-resources) section also lists the apporximate time each module takes to be completed.
+To lay out and schedule the plan, the [Core Skills training resources](/resources/training-resources#core-skills-training-resources) section also lists the approximate time each module takes to be completed.
 
-The whole set of training resources available for the Core Skills, sums up to almost 90 hours of potential study and practice, with topics like the shell, Git and Kubernetes taking the lion's share. Hands-on are often the more time consuming, but they may be the most effective too. Pick the stuff that sounds more reasonable, or limit the hands on to the parts that are most relevant to the project <sup><a href="#fn1">1</a></sup>.
+The whole set of training resources available for the Core Skills sums up to almost 90 hours of potential study and practice, with topics like the shell, Git, and Kubernetes taking the lion's share. Hands-on are often the more time-consuming, but they may be the most effective too. Pick the stuff that sounds more reasonable, or limit the hands-on to the parts that are most relevant to the project <sup><a href="#fn1">1</a></sup>.
 
 If the emerging plan adds up to more than 40 hours, consider the following priority lists, depending on the job position:
 
@@ -135,19 +135,19 @@ If the emerging plan adds up to more than 40 hours, consider the following prior
 ### Schedule the effort
 
 There are several variables that can influence the schedule for study hours, like expertise, background, or learning speed of the new entry, project deadlines, needs, organization, customer-related constraints, etc.  
-Therefore, each team-leader is free to decide how to plan the training with the new employee, as long as it's done within the first two months.
+Therefore, each team leader can decide how to plan the training with the new employee, as long as it's done within the first two months.
 
-For example, imagining that the training path takes up all 40 hours, they can decide to spend 10 consecutive afternoons for the first ten working days. Or they may want to seize some slack the project may grant for the first week to go all-in and spend it all learning the basics.  
-Or maybe they may decide to spend a couple days on the most relevant knowledge gaps, and postpone for a couple weeks the refresh of already familiar concepts.
+For example, imagining that the training path takes up all 40 hours, they can decide to spend 10 consecutive afternoons for the first 10 working days. Or they may want to seize some slack the project may grant for the first week to go all-in and spend it all learning the basics.  
+Or maybe they may decide to spend a couple of days on the most relevant knowledge gaps and postpone for a couple of weeks the refresh of already familiar concepts.
 
 It's strongly suggested to:
 
-* Plan the sessions on Float under the `Tech Budget / Formazione interna` project. The time spent will **must** be logged there anyway.
+* Plan the sessions on Float under the `HR Budget / Core Skills Training` project. The time spent will **must** be logged there anyway.
 * Assign a task on PeopleForce for each module, with the links to the training material, possibly numbered, so that the employee can check them out as complete. This will trigger a notification to whomever assigned the task allowing the team leader or buddy to see the progress.
 
-### When to assess, plan, communicate and verify
+### When to assess, plan, communicate, and verify
 
-This table summarize the key moments to make sure the Core Skills has been properly acquired.
+This table summarizes the key moments to make sure the Core Skills have been properly acquired.
 
 | When                             | What                                                    | Who              |
 |----------------------------------|---------------------------------------------------------|------------------|
@@ -159,10 +159,10 @@ This table summarize the key moments to make sure the Core Skills has been prope
 |                                  | Implement the training plan                             | New entry        |
 | **During second month**          |                                                         |                  |
 |                                  | During planned 1-on-1, gets feedback about the progress | HR               |
-|                                  | Continuous evaluation and process updates               | HR, TL, newentry |
+|                                  | Continuous evaluation and process updates               | HR, TL, new entry |
 | **End of second month**          |                                                         |                  |
-|                                  | Review and evaluate training results                    | HR, TL, newentry |
+|                                  | Review and evaluate training results                    | HR, TL, new entry |
 
 ---
 
-<small><a name="fn1">1</a>: Of course, the resources are always there in case someone has spare time or want to skill-up in their personal time.</small>
+<small><a name="fn1">1</a>: Of course, the resources are always there in case someone has spare time or wants to skill up in their personal time.</small>

--- a/content/procedures/assessing-core-skills.md
+++ b/content/procedures/assessing-core-skills.md
@@ -2,11 +2,22 @@ During the onboarding of a new employee, a buddy or team leader is called to ass
 
 The required level of proficiency vary depending on the seniority and job position, but a minimum degree of literacy is required, as explained [here](/working-at-sparkfabrik/core-skills).
 
-To ease the process, we hereby provide guidelines for each [core skill](/working-at-sparkfabrik/core-skills) set.
+To ease the process, the [list of core skills](/working-at-sparkfabrik/core-skills#technical-core-skills), the [related training resources](/resources/training-resources#core-skills-training-resources) and the following assessment suggestions, are all separated into _modules_ (like _Networking_, _Security_, _Docker and Docker Compose_). Such modules are grouped in three main areas: _Basics_, _Tools_ and _DevOps_.
 
-## Command line / Shell
+The procedure is easy:
+
+* Use the guidelines and checklists below to assess the necessary skill level.
+* If the degree of confidence is low (most of the checklist elements are unknown or uncertain), the whole module is worth studying from scratch. If most of the topics are known and just a few ancillary are missing (ex. the assessee never used `sed` and `awk` but for the rest she's confident with a Unix shell), than the module may be skipped.
+* Take a list of the modules that have to be studied.
+* Head to the [Plan the training on Core Skills](#plan-the-training-on-core-skills) section below to schedule the training.
+
+## Assess Core Skills proficiency
+
+Follow this section, module by module.
 
 ### Basics
+
+#### Command line / Shell
 
 Software Developers should have a basic understanding of:
 
@@ -24,18 +35,7 @@ Senior Software Developers and Cloud Native Engineers should be confident with t
 * **Scripting**: Variables, arguments, cycles, conditions, functions, echoing
 * **Text processing**: `grep`, `sed`, `awk`
 
-### Networking
-
-Software Developers should have a basic understanding of:
-
-* Interfaces and ports, what's `localhost`, how domain names resolution works, HTTP basics, how HTTPS works.
-
-Senior Software Developers and Cloud Native Engineers should have a clear understanding about:
-
-* TCP/UDP-IP protocol, the concept of application-level protocols, DNS configuration basics (authoritative zone, record types, TTL and propagation), local domains resolution.
-
-
-### Security
+#### Security
 
 Software Developers should have a basic understanding of:
 
@@ -48,7 +48,26 @@ Senior Software Developers and Cloud Native Engineers should have a clear unders
 * GPG, difference between authentication and authorization, OAuth framework, hashing
 * Best-practices for the development of secure software
 
-### Git
+#### Networking
+
+Software Developers should have a basic understanding of:
+
+* Interfaces and ports, what's `localhost`, how domain names resolution works, HTTP basics, how HTTPS works.
+
+Senior Software Developers and Cloud Native Engineers should have a clear understanding about:
+
+* TCP/UDP-IP protocol, the concept of application-level protocols, DNS configuration basics (authoritative zone, record types, TTL and propagation), local domains resolution.
+
+### Tools
+
+#### YAML
+
+Everyone should have a basic understanding of:
+
+* Basic knowledge of the use-cases and syntax
+* Knowledge of features like comments or references
+
+#### Git
 
 Everyone should have a basic understanding of:
 
@@ -57,34 +76,93 @@ Everyone should have a basic understanding of:
 * **Workflow**: different branching models (git-flow, GitHub or Gitlab flow), pull/merge request, peer review, squashing commits, rebase and merge, merge commits, linear history
 * **Conventions**: understand the relation between workflow-related conventions (commit granularity, versioning, commit messages format, branching model, etc) and the working context (social contracts, environments, cadences, etc)
 
+#### GitHub Copilot
 
-## DevOps
+That's a "bonus track". Developers are the most impacted by the usage of Copilot, so just ask if they know what it is and if they every tried it.
 
-### Docker and docker-compose
+### DevOps
 
-* **Concepts**: Docker daemon and client, images, tags, digest, containers, volumes, registries and DockerHub
+#### Docker and docker-compose
 
+Software Developers should have a basic understanding of:
+
+* **Concepts**: Docker daemon and client, general anatomy of a Dockerfile, images, tags, digest, containers, volumes, registries, and what is DockerHub
 * **Basic commands**: pull, push, run, stop, ls, rm, ps, prune
-* **Dockerfiles**: levels, caching, basic commands (FROM, COPY, ADD, RUN, ENTRYPOINT, CMD, ENV, ARG), multi stage builds
 * **Docker-Compose**: 
   * Understanding declarative approach
   * Anatomy of the `docker-compose.yml` file (services, build, volumes, ports, etc)
-  * How networking and hostname resolution works between docker-composed containers
   * Basic commands (up, down, logs) and detachment
 
-### Kubernetes
+Senior Software Developers and Cloud Native Engineers should be confident with the above, plus having a more specific understanding of:
+
+* **Dockerfiles**: levels, caching, basic commands (FROM, COPY, ADD, RUN, ENTRYPOINT, CMD, ENV, ARG), multi stage builds
+* **Docker-Compose**: 
+  * How networking and hostname resolution works between docker-composed containers
+
+#### Kubernetes
+
+Everyone should have a basic understanding of:
 
 * **Concepts**: multi-services architectures, orchestration, telemetry and monitoring, 12-Factors applications
 * **Building blocks**: clusters, nodes, deployments, pods, services, storage, networking
 
-### YAML
+#### CI/CD
 
-* Basic knowledge of the use-cases and syntax
-* Knowledge of features like comments or references
-
-## Continuous Integration / Continuous Delivery
+Everyone should have a basic understanding of:
 
 * **Concepts**: what does integration and deploy mean, what does continuously integrating means and why it's important, the relation between integration and tests
 * **Building blocks**: Git, remotes, the different types of tests (unit, integration, functional, end-to-end), builds, deploys
 * **Common environments**: `development` (integration), `stage`, and `production`
 * **Delivery automation**: GitLab Pipelines and GitHub Actions
+
+## Plan the training on Core Skills
+
+### Laying out contents
+
+Depending on the findings of the assessment phase (described above), **a maximum of 40 working hours** will be allocated **within the first two two months** for the new employee to learn the key-concepts.
+
+
+To layout and schedule the plan, the [Core Skills training resources](/resources/training-resources#core-skills-training-resources) section also lists the apporximate time each module takes to be completed.
+
+The whole set of training resources available for the Core Skills, sums up to almost 90 hours of potential study and practice, with topics like the shell, Git and Kubernetes taking the lion's share. Hands-on are often the more time consuming, but they may be the most effective too. Pick the stuff that sounds more reasonable, or limit the hands on to the parts that are most relevant to the project <sup><a href="#fn1">1</a></sup>.
+
+If the emerging plan adds up to more than 40 hours, consider the following priority lists, depending on the job position:
+
+* **Web developers**: Command line / Shell, Git, Docker and Docker Compose, Security (excepted the hands-on), YAML, CI/CD (excepted the hands-on), Kubernetes (except the hands-on).
+* **Mobile developers**: Command line / Shell, Git, YAML, CI/CD (excepted the hands-on),  Security (excepted the hands-on), Docker and Docker Compose, Kubernetes (except the hands-on).
+* **Cloud Engineers**: Command line / Shell, Git, CI/CD, Security, Docker and Docker Compose, YAML, Kubernetes.
+
+### Schedule the effort
+
+There are several variables that can influence the schedule for study hours, like expertise, background, or learning speed of the new entry, project deadlines, needs, and organization, customer-related constraints, etc.  
+Therefore, each team-leader is free to decide how to plan the training with the new employee, as long as it's done within the first two months.
+
+For example, imagining that the training path takes up all 40 hours, they can decide to spend 10 consecutive afternoons for the first ten working days. Or they may want to seize some slack the project may grant for the first week to go all-in and spend it all learning the basics.  
+Or maybe they may decide to spend a couple days on the most relevant knowledge gaps, and postpone for a couple weeks the refresh of already familiar concepts.
+
+It's strongly suggested to:
+
+* Plan the sessions on Float under the `Tech Budget / Formazione interna` project. The time spent will **must** be logged there anyway.
+* Assign a task on PeopleForce for each module, with the links to the training material, possibly numbered, so that the employee can check them out as complete. This will trigger a notification to whomever assigned the task allowing the team leader or buddy to see the progress.
+
+### When to assess, plan, communicate and verify
+
+This table summarize the key moments to make sure the Core Skills has been properly acquired.
+
+| When                             | What                                                    | Who              |
+|----------------------------------|---------------------------------------------------------|------------------|
+| **From 2nd day of onboarding**   |                                                         |                  |
+|                                  | Assess required core skills and training needs          | TL and new entry |
+|                                  | Create a proposal to allocate training hours            | TL               |
+|                                  | Planning review and approval                            | Ops and/or CTO   |
+| **During first month**           |                                                         |                  |
+|                                  | Implement the training plan                             | New entry        |
+| **During second month**          |                                                         |                  |
+|                                  | During planned 1-on-1, gets feedback about the progress | HR               |
+|                                  | Continuous evaluation and process updates               | HR, TL, newentry |
+| **End of second month**          |                                                         |                  |
+|                                  | Review and evaluate training results                    | HR, TL, newentry |
+
+---
+
+<small><a name="fn1">1</a>: Of course, the resources are always there in case someone has spare time or want to skill-up in their personal time.</small>

--- a/content/procedures/assessing-core-skills.md
+++ b/content/procedures/assessing-core-skills.md
@@ -26,7 +26,7 @@ Software Developers should have a basic understanding of:
   * **Search**: `find`, `which`
   * **File management**: `cat`, `less`/`more`, `head`/`tail`, `touch`
   * **Permissions**: `chmod` and `chown`, permissions sets, file attributes
-* **Shell configuration**: `.profile`/`.zprofile`, ``.bashrc`/`.zshrc`, environment variables, path and command scope, etc
+* **Shell configuration**: `.profile`/`.zprofile`, `.bashrc`/`.zshrc`, environment variables, path and command scope, etc
 * **Redirection**: `stdout`, `stderr`, reading, writing, overwriting, appending to streams
 * **Make/Makefile**: targets, dependencies, recipes, rules
 

--- a/content/procedures/assessing-core-skills.md
+++ b/content/procedures/assessing-core-skills.md
@@ -73,7 +73,7 @@ Everyone should have a basic understanding of:
 
 * **Basic usage**: status, staging, commit, tag, reset, history / log, branch, remotes, merge, rebase, cherry picking, push, pull
 * **Concepts**: what's a repository, the working tree, the `.gitignore` file, how to diff and move along the commit history
-* **Workflow**: different branching models (git-flow, GitHub or Gitlab flow), pull/merge request, peer review, squashing commits, rebase and merge, merge commits, linear history
+* **Workflow**: different branching models (git-flow, GitHub or GitLab flow), pull/merge request, peer review, squashing commits, rebase and merge, merge commits, linear history
 * **Conventions**: understand the relation between workflow-related conventions (commit granularity, versioning, commit messages format, branching model, etc) and the working context (social contracts, environments, cadences, etc)
 
 #### GitHub Copilot
@@ -95,7 +95,7 @@ Software Developers should have a basic understanding of:
 
 Senior Software Developers and Cloud Native Engineers should be confident with the above, plus having a more specific understanding of:
 
-* **Dockerfiles**: levels, caching, basic commands (FROM, COPY, ADD, RUN, ENTRYPOINT, CMD, ENV, ARG), multi stage builds
+* **Dockerfiles**: levels, caching, basic commands (FROM, COPY, ADD, RUN, ENTRYPOINT, CMD, ENV, ARG), multi stage and multi arch builds
 * **Docker-Compose**: 
   * How networking and hostname resolution works between docker-composed containers
 

--- a/content/procedures/employee-onboarding.md
+++ b/content/procedures/employee-onboarding.md
@@ -94,7 +94,7 @@ The Team Leader will also make sure that:
 
 ## Things to do within the first week
 
-* The buddy reviews the core-skills list with the colleague and a training plan is laid out on the topics that need upskilling
+* The buddy [assesses the core skills with the colleague](/procedures/assessing-core-skills) and a [training plan is laid out](/procedures/assessing-core-skills#plan-the-training-on-core-skills) on the topics that need upskilling
 * HR and the employee will schedule a 30 mins self-introduction to the whole company
 * HR will schedule a one-on-one meeting with the employee at the end of the second week, to check in on the [onboarding goals](/guides/an-effective-onboarding-structure)
 * The Team Leader will schedule a one-on-one meeting with the employee at the end of the first month, to exchange feedback and set the goals for the next couple months

--- a/content/procedures/git-workflow.md
+++ b/content/procedures/git-workflow.md
@@ -1,5 +1,3 @@
-
-
 ## Prerequisites and definitions
 
 * `develop` is the *integration branch*

--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -46,9 +46,12 @@ All the training material in this section is public and can be freely accessed.
     #table-styler-code-skills table th:nth-of-type(2) { width: 75%; }
 </style>
 <div id="table-styler-code-skills">
+
 ## Basics
 
 ### Command line / Shell
+
+> **Time to completion**: 24 hours.
 
 | Resources | |
 |---|---|
@@ -58,6 +61,8 @@ All the training material in this section is public and can be freely accessed.
 | | [Bash Crawl (SlackerMedia)](https://gitlab.com/slackermedia/bashcrawl#try-it-online-with-mybinder) |
 
 ### Security
+
+> **Time to completion**: 4 hours for the documentation; hands-on are considered a long-term goal, check the note.
 
 | Resources | |
 |---|---|
@@ -69,6 +74,8 @@ All the training material in this section is public and can be freely accessed.
 
 ### Networking
 
+> **Time to completion**: 1 hour.
+
 | Resources | |
 |---|---|
 | **Documentation** | [How DNS works](https://howdns.works/ep1/) |
@@ -78,6 +85,7 @@ All the training material in this section is public and can be freely accessed.
 
 ### YAML
 
+> **Time to completion**: 1 hour.
 | Resources | |
 |---|---|
 | **Documentation** | [YAML Syntax (Ansible Documentation)](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html) |
@@ -85,18 +93,21 @@ All the training material in this section is public and can be freely accessed.
 
 ### Git
 
+> **Time to completion**: 12 hours for the documentation; 18 hours for the hands-on.
+
 | Resources | |
 |---|---|
 | **Documentation** | [Git Tutorial (NuLab)](https://nulab.com/learn/software-development/git-tutorial/) |
 | | [Understanding Git Conceptually](https://www.cduan.com/technical/git/) |
-| | [Git Workflow](https://playbook.sparkfabrik.com/procedures/git-workflow) |
+| | [SparkFabrik Git Workflow](https://playbook.sparkfabrik.com/procedures/git-workflow) |
 | | [Gitlab Flow](https://docs.gitlab.com/ee/topics/gitlab_flow.html) |
 | **Hands-on** | [Learning Git Branching](https://learngitbranching.js.org/) |
 | | [Oh my Git](https://ohmygit.org/) |
 | | [Visualizing Git](https://git-school.github.io/visualizing-git/) |
 
-
 ### GitHub Copilot
+
+> **Time to completion**: 1 hours for the documentation and installation.
 
 | Resources | |
 |---|---|
@@ -107,7 +118,7 @@ All the training material in this section is public and can be freely accessed.
 
 ### Docker and Docker Compose
 
-Our local stack always includes one or more containers with the services that compose the application, typically reflecting the production architecture.
+> **Time to completion**: 3 hours for the documentation; 3 hours for the hands-on.
 
 | Resources | |
 |---|---|
@@ -117,15 +128,16 @@ Our local stack always includes one or more containers with the services that co
 
 ### Kubernetes
 
-Our preferred infrastructure to manage multi-service applications.
+> **Time to completion**: 1 hour for the documentation; 12 hours for the hands-on.
 
 | Resources | |
 |---|---|
 | **Documentation** | [The Illustrated Childrens Guide to Kubernetes (Italian)](https://www.cncf.io/wp-content/uploads/2021/11/The-Illustrated-Childrens-Guide-to-Kubernetes-Italian-Spark.pdf) |
 | **Hands-on** | [Kubernetes (KillerCoda)](https://killercoda.com/kubernetes) <sup><a href="#fn2">2</a></sup> |
 
+### CI/CD1
 
-### CI/CD
+> **Time to completion**: 4 hour for the documentation; 4 hours for the hands-on.
 
 | Resources | |
 |---|---|

--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -2,22 +2,140 @@ SparkFabrik offers access to a set of training resources.
 
 Some of them are _self-service_ and can be accessed by every employee as they see fit. Some others are licensed on a per-seat basis and require the creation of a personal account and relative license.
 
-This page lists all the available resources, providing a link to them and a mean to obtain access when required.
+This page lists all the available resources, providing a link to them and a mean to obtain access when required.  
+
+A [specific section](#core-skills-training-resources) in this page lists the educational material to be used for the acquisition of the core skills, during the onboarding period.
 
 At the bottom of this page, in the [Filing training requests](#filing-training-requests) section, we explain how to submit requests for specific training courses/resources and keep an eye on new training resources that SparkFabrik may make available to everyone.
 
-## Training resources
+## Table of contents
 
 Please find here a TOC of the available training resources.
 
+**Core skills training resources**
+
+| Area | Topic |
+|---|---|
+| [Basics](#basics) | [Command line / Shell](#command-line--shell) |
+|        | [Security](#security) |
+|        | [Networking](#networking) |
+| [Tools](#tools) | [YAML](#yaml) |
+|        | [Git](#git) |
+|        | [GitHub Copilot](#github-copilot) (bonus track) |
+| [DevOps](#devops) | [Docker and Docker Compose](#docker-and-docker-compose) |
+|        | [Kubernetes](#kubernetes) |
+|        | [CI/CD](#cicd) (on Gitlab and GitHub) |
+
+**Other training resources**
+
 | Name | Area | Topics | Access type |
 |---|---|---|---|
-| [Udemy](#udemy)| Development | Angular, React, React Native, Hasura | Credentials |
+| [Udemy](#udemy) | Development | Angular, React, React Native, Hasura | Credentials |
 | [Ultimate Courses](#ultimate-courses) | Development | Angular, React, Typescript | Credentials |
 | [Drupalize.me](#drupalizeme) | Development | Drupal | Credentials |
 | [AWS Skill Builder](#aws-skill-builder) | Cloud | Amazon Web Services | Corporate account |
 | [Google SkillBoost](#google-skillboost) | Cloud | Google Cloud Platform | Corporate account |
 | [Cloud Academy](#cloud-academy) | Cloud | Vendor-specific services (AWS, GCP, Azure, Alibaba), Kubernetes, complete Cloud training offering | Reserved seats |
+
+## Core Skills training resources
+
+All the training material in this section is public and can be freely accessed.
+
+<style>
+    #table-styler-code-skills table th:first-of-type { width: 25%;}
+    #table-styler-code-skills table th:nth-of-type(2) { width: 75%; }
+</style>
+<div id="table-styler-code-skills">
+## Basics
+
+### Command line / Shell
+
+| Resources | |
+|---|---|
+| **Documentation** | [Makefile Tutorial](https://makefiletutorial.com/) |
+| **Hands-on** | [The Shell (LinuxJourney)](https://linuxjourney.com/lesson/the-shell) |
+| | [Output redirection (LinuxJourney)](https://linuxjourney.com/lesson/stdout-standard-out-redirect) |
+| | [Bash Crawl (SlackerMedia)](https://gitlab.com/slackermedia/bashcrawl#try-it-online-with-mybinder) |
+
+### Security
+
+| Resources | |
+|---|---|
+| **Documentation** | [Concise Guide for Developing More Secure Software (OpenSSF)](https://best.openssf.org/Concise-Guide-for-Developing-More-Secure-Software.html) |
+| | [Concise Guide for Evaluating Open Source Software (OpenSSF)](https://best.openssf.org/Concise-Guide-for-Evaluating-Open-Source-Software.html) |
+| | [Source Code Management Best Practices Guide (OpenSSF)](https://best.openssf.org/SCM-BestPractices/) |
+| | [The Secure Software Factory (CNCF Tag Security Whitepaper)](https://github.com/cncf/tag-security/blob/main/supply-chain-security/secure-software-factory/Secure_Software_Factory_Whitepaper.pdf) |
+| **Hands-on** | [Developing Secure Software (LFD121)](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/) <sup><a href="#fn1">1</a></sup> |
+
+### Networking
+
+| Resources | |
+|---|---|
+| **Documentation** | [How DNS works](https://howdns.works/ep1/) |
+| | [How HTTPS works](https://howhttps.works/) |
+
+## Tools
+
+### YAML
+
+| Resources | |
+|---|---|
+| **Documentation** | [YAML Syntax (Ansible Documentation)](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html) |
+| **Hands-on** | [YAML Tutorial - Everything you need get started (CloudBees)](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started) |
+
+### Git
+
+| Resources | |
+|---|---|
+| **Documentation** | [Git Tutorial (NuLab)](https://nulab.com/learn/software-development/git-tutorial/) |
+| | [Understanding Git Conceptually](https://www.cduan.com/technical/git/) |
+| | [Git Workflow](https://playbook.sparkfabrik.com/procedures/git-workflow) |
+| | [Gitlab Flow](https://docs.gitlab.com/ee/topics/gitlab_flow.html) |
+| **Hands-on** | [Learning Git Branching](https://learngitbranching.js.org/) |
+| | [Oh my Git](https://ohmygit.org/) |
+| | [Visualizing Git](https://git-school.github.io/visualizing-git/) |
+
+
+### GitHub Copilot
+
+| Resources | |
+|---|---|
+| **Documentation** | [Quickstart for GitHub Copilot](https://docs.github.com/en/copilot/quickstart) |
+| | [SparkFabrik's policy on Copilot](/tools-and-policies/github-copilot) |
+
+## DevOps
+
+### Docker and Docker Compose
+
+Our local stack always includes one or more containers with the services that compose the application, typically reflecting the production architecture.
+
+| Resources | |
+|---|---|
+| **Documentation** | [Docker - Zero to Hero (TechWorld with Nana - YouTube)](https://youtu.be/3c-iBn73dDE) |
+| | [Docker-Compose Tutorial (TechWorld with Nana - YouTube)](https://youtu.be/MVIcrmeV_6c) |
+| **Hands-on** | [Docker 101 Tutorial](https://www.docker.com/101-tutorial/) |
+
+### Kubernetes
+
+Our preferred infrastructure to manage multi-service applications.
+
+| Resources | |
+|---|---|
+| **Documentation** | [The Illustrated Childrens Guide to Kubernetes (Italian)](https://www.cncf.io/wp-content/uploads/2021/11/The-Illustrated-Childrens-Guide-to-Kubernetes-Italian-Spark.pdf) |
+| **Hands-on** | [Kubernetes (KillerCoda)](https://killercoda.com/kubernetes) <sup><a href="#fn2">2</a></sup> |
+
+
+### CI/CD
+
+| Resources | |
+|---|---|
+| **Documentation** | [Introduction to CI (GitLab Documentation)](https://docs.gitlab.com/ee/ci/introduction/) |
+| | [Create and run your first GitLab CI/CD pipeline (GitLab Tutorial)](https://docs.gitlab.com/ee/ci/quick_start/) |
+| | [GitLab CI/CD in one hour (TechWorld with Nana - YouTube)](https://youtu.be/qP8kir2GUgo) |
+| | [Understanding GitHub Actions (GitHub Docs)](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) |
+| **Hands-on** | [Become a GitHub Actions Hero](https://github-actions-hero.vercel.app/) |
+
+## Other training resources
 
 ### Development
 
@@ -108,3 +226,9 @@ The requests will be evaluated by the management taking into account many factor
 * Your training track record (if any)
 
 To speed up the evaluation process, please make sure to provide detailed information, following each field's suggestion.
+
+---
+
+<small><a name="fn1">1</a>: The "Developing Secure Software" course (LFD121) is considered a long-term goal to be completed within the first 12 months after the probationary period.</small><br>
+<small><a name="fn2">2</a>: Limit hands-on exercices to “Pod Intro”, “Deployment Basics” and “A Playground” sections.</small>
+</div>

--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -24,7 +24,7 @@ Please find here a TOC of the available training resources.
 |        | [GitHub Copilot](#github-copilot) (bonus track) |
 | [DevOps](#devops) | [Docker and Docker Compose](#docker-and-docker-compose) |
 |        | [Kubernetes](#kubernetes) |
-|        | [CI/CD](#cicd) (on Gitlab and GitHub) |
+|        | [CI/CD](#cicd) (on GitLab and GitHub) |
 
 **Other training resources**
 
@@ -100,7 +100,7 @@ All the training material in this section is public and can be freely accessed.
 | **Documentation** | [Git Tutorial (NuLab)](https://nulab.com/learn/software-development/git-tutorial/) |
 | | [Understanding Git Conceptually](https://www.cduan.com/technical/git/) |
 | | [SparkFabrik Git Workflow](https://playbook.sparkfabrik.com/procedures/git-workflow) |
-| | [Gitlab Flow](https://docs.gitlab.com/ee/topics/gitlab_flow.html) |
+| | [GitLab Flow](https://docs.gitlab.com/ee/topics/gitlab_flow.html) |
 | **Hands-on** | [Learning Git Branching](https://learngitbranching.js.org/) |
 | | [Oh my Git](https://ohmygit.org/) |
 | | [Visualizing Git](https://git-school.github.io/visualizing-git/) |
@@ -135,7 +135,7 @@ All the training material in this section is public and can be freely accessed.
 | **Documentation** | [The Illustrated Childrens Guide to Kubernetes (Italian)](https://www.cncf.io/wp-content/uploads/2021/11/The-Illustrated-Childrens-Guide-to-Kubernetes-Italian-Spark.pdf) |
 | **Hands-on** | [Kubernetes (KillerCoda)](https://killercoda.com/kubernetes) <sup><a href="#fn2">2</a></sup> |
 
-### CI/CD1
+### CI/CD
 
 > **Time to completion**: 4 hour for the documentation; 4 hours for the hands-on.
 

--- a/content/working-at-sparkfabrik/core-skills.md
+++ b/content/working-at-sparkfabrik/core-skills.md
@@ -1,0 +1,256 @@
+/*
+Description: Basic technical skills by department
+Sort: 30
+*/
+
+**Core skills** are those shared across all teams, whether Platform or Development teams, and they form the foundation we expect all professionals at SparkFabrik to have.
+
+The purpose of this document is to list the training resources to consolidate the key competencies we recognize in every professional. 
+
+The training resources will be useful during the onboarding period at the company to self-train and update knowledge, with the support of a "buddy" who will be available throughout the process. 
+
+The ideal approach is to have an interactive, guided path already designed with a "Getting Started" perspective that provides insights for further exploration without going “too deep”.
+
+This page lists all core skills, split into modules, each of which concludes with a simple self-assessment to be completed individually or with the support of the buddy, who could help to understand if the key-concepts are well understood. 
+
+For each identified core skill, we provide one or more links to educational materials and hands-on tutorials.
+
+## General Resources
+
+In our Playbook, you can find a list of educational materials in the form of online courses available on the most popular training platforms. The [dedicated page](https://playbook.sparkfabrik.com/resources/training-resources) also contains information on how to access this material.
+
+
+## Core modules
+
+---
+
+### Command-line / Shell
+
+#### Basics
+
+The command-line is one of the tools we use extensively to standardize the developer experience and automatically share secrets and settings across all projects.
+
+##### Documentation
+
+* Makefile: [https://makefiletutorial.com/](https://makefiletutorial.com/)
+
+##### Hands-on
+
+* [https://linuxjourney.com/lesson/the-shell](https://linuxjourney.com/lesson/the-shell)
+* [https://linuxjourney.com/lesson/stdout-standard-out-redirect](https://linuxjourney.com/lesson/stdout-standard-out-redirect)
+* [https://gitlab.com/slackermedia/bashcrawl#try-it-online-with-my binder](https://gitlab.com/slackermedia/bashcrawl#try-it-online-with-mybinder)
+
+
+#### Security
+
+Any credentials (API keys, passwords, etc.) should not be committed to the project and should not be present on the local disk, especially if it is not encrypted. Credentials should only be saved within secure tools provided by our platforms, such as GitLab/GitHub.
+
+##### Documentation
+
+* OpenSSF: [Concise Guide for Developing More Secure Software](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Developing-More-Secure-Software.md#readme)
+* OpenSSF: [Concise Guide for Evaluating Open Source Software](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Evaluating-Open-Source-Software.md#readme)
+* CNCF Tag Security: [The Secure Software Factory](https://github.com/cncf/tag-security/blob/main/supply-chain-security/secure-software-factory/Secure_Software_Factory_Whitepaper.pdf) (whitepaper)
+
+##### Hands-on
+
+* [Developing Secure Software (LFD121)](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/) (14-18h)
+
+_Note:_ The "Developing Secure Software" course (LFD121) is considered a long-term goal to be completed within the first 12 months after the probationary period.
+
+#### Git
+
+Git is the fundamental tool we use to work on any development project, both internal and external.
+
+##### Documentation
+
+* Git workflow: [https://playbook.sparkfabrik.com/procedures/git-workflow](https://playbook.sparkfabrik.com/procedures/git-workflow)
+* [https://docs.gitlab.com/ee/topics/gitlab_flow.html](https://docs.gitlab.com/ee/topics/gitlab_flow.html)
+
+##### Hands-on
+
+* [https://learngitbranching.js.org/](https://learngitbranching.js.org/)
+
+
+#### Timing and Assessment
+
+_Estimated Time:_ 24h
+
+Assessment: SparkFabrik will provide a private repository to clone, containing an application with some errors in build and startup scripts, and security practices. The candidate should correct these errors to make the application run.
+
+---
+
+### DevOps
+
+
+#### Docker e Docker Compose
+
+Our local stack always includes one or more containers with the services that compose the application, typically reflecting the production architecture.
+
+##### Documentation
+
+* [https://youtu.be/3c-iBn73dDE](https://youtu.be/3c-iBn73dDE)
+* [https://youtu.be/MVIcrmeV_6c](https://youtu.be/MVIcrmeV_6c) 
+
+##### Hands-on
+
+* [https://www.docker.com/101-tutorial/](https://www.docker.com/101-tutorial/)
+
+#### Kubernetes
+
+Our preferred infrastructure to manage multi-service applications.
+
+##### Documentation
+
+* [https://www.cncf.io/wp-content/uploads/2021/11/The-Illustrated-Childrens-Guide-to-Kubernetes-Italian-Spark.pdf](https://www.cncf.io/wp-content/uploads/2021/11/The-Illustrated-Childrens-Guide-to-Kubernetes-Italian-Spark.pdf)
+
+##### Hands-on
+
+* [https://killercoda.com/kubernetes](https://killercoda.com/kubernetes) - “Pod Intro”, “Deployment Basics” and “A Playground”
+
+
+#### YAML
+
+The format is used to describe almost all cloud-native services, such as Docker Compose and Kubernetes.
+
+##### Documentation
+
+* [https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html)
+
+##### Hands-on
+
+* [https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started)
+
+
+#### Timing and Assessment
+
+_Estimated Time:_  18h
+
+_Assessment:_ SparkFabrik will provide a private repository to create a mini-project with Docker and Kubernetes (kind), hypothetically a web app with an nginx server.
+
+
+### Continuous Integration (CI/CD)
+
+
+#### GitLab & GitHub
+
+These are our reference tools to manage repositories, projects (agile boards), and continuous integration with automated pipelines.
+
+##### Documentation
+
+* [https://docs.gitlab.com/ee/ci/introduction/](https://docs.gitlab.com/ee/ci/introduction/)
+* [https://docs.gitlab.com/ee/ci/quick_start/](https://docs.gitlab.com/ee/ci/quick_start/)
+* [https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions)
+* [https://youtu.be/qP8kir2GUgo](https://youtu.be/qP8kir2GUgo)
+
+##### Hands-on
+
+* [https://github-actions-hero.vercel.app/](https://github-actions-hero.vercel.app/)
+
+#### Timing and Assessment
+
+_Estimated Time:_ 8h
+
+Assessment: SparkFabrik will provide a private repository with CI and job templates, and tasks such as adding a new job, retrieving logs, or fixing non-functioning jobs.
+
+### Bonus: GitHub Copilot
+
+A tool that utilizes AI to auto-complete code more intelligently. When used correctly, it allows us to optimize repetitive tasks and quickly create prototypes and blueprints.
+
+Documentation
+
+[https://playbook.sparkfabrik.com/tools-and-policies/github-copilot](https://playbook.sparkfabrik.com/tools-and-policies/github-copilot)
+
+_Estimated Time: _1h
+
+
+### Summary
+
+| Module                             | Suggested Time (hours)     |
+|------------------------------------|----------------------------|
+| Command-line / Shell               | 50% on total hours         |
+| DevOps                             | 35% on total hours         |
+| Continuous Integration (CI/CD)     | 15% on total hours         |
+| Total hours                        | 40                         |
+
+
+#### Team Tracks 
+
+
+##### Developers
+
+| Module               | Topic                    |
+|----------------------|--------------------------|
+| Command-line / Shell | Basics                   |
+| Command-line / Shell | Git                      |
+| DevOps               | Docker & Docker compose  |
+| Command-line / Shell | Security                 |
+| DevOps               | YAML                     |
+| CI/CD                | GitLab & GitHub (basics) |
+| DevOps               | Kubernetes (basics)      |
+
+
+
+##### Mobile
+
+| Module               | Topic                    |
+|----------------------|--------------------------|
+| Command-line / Shell | Basics                   |
+| Command-line / Shell | Git                      |
+| DevOps               | YAML                     |
+| CI/CD                | GitLab & GitHub (basics) |
+| Command-line / Shell | Security                 |
+| DevOps               | Docker & Docker compose  |
+| DevOps               | Kubernetes (basics)      |
+
+
+##### Platform
+
+| Module               | Topic                   |
+|----------------------|-------------------------|
+| Command-line / Shell | Basics                  |
+| Command-line / Shell | Git                     |
+| CI/CD                | GitLab & GitHub         |
+| Command-line / Shell | Security                |
+| DevOps               | Docker & Docker compose |
+| DevOps               | YAML                    |
+| DevOps               | Kubernetes              |
+
+
+---
+
+##### How to allocate study hours
+
+| When                                          | What                                                                   | Who              |
+|-----------------------------------------------|------------------------------------------------------------------------|------------------|
+|                                               | Assess required core skills and training needs (checklist)             | TL and new entry |
+| From the 2nd day of onboarding                | Create a proposal to allocate study hours (*)                          | TL               |
+|                                               | Revisione e approvazione del piano                                     | Ops and/or CTO   |
+| During first month                            | Implement the study plan                                               | New entry        |
+| Second month                                  | Individual meetings (1:1) to collect feedback on the training progress | HR               |
+|                                               | Continuous evaluation and process updates                              | HR, TL, newentry |
+
+
+(*) There are several variables that can influence the allocation of study hours:
+
+
+* Expertise and background of the new entry 
+* Project (deadlines, needs, organization, contact with the client) 
+* Learning speed 
+* … what else? TODO
+
+**Total hours Available: **40 hours
+
+**Examples of study hour allocation:** 
+
+_Example 1_
+
+_40 hours to allocate _
+
+_10 half-days consecutively for the first 10 working days_
+
+_Example 2_
+
+_40 hours to allocate _
+
+
+## _2 half-days per week for 5 weeks_

--- a/content/working-at-sparkfabrik/core-skills.md
+++ b/content/working-at-sparkfabrik/core-skills.md
@@ -3,111 +3,43 @@ Description: Basic technical skills by department
 Sort: 30
 */
 
-**Core skills** are those shared across all teams, whether Platform or Development teams, and they form the foundation we expect all professionals at SparkFabrik to have.
+**Core skills** are shared across all teams, whether Platform or Development ones, and they form the foundation we expect all professionals at SparkFabrik to have.
 
-The purpose of this document is to list the training resources to consolidate the key competencies we recognize in every professional.
-
-The training resources will be useful during the [onboarding period](/procedures/employee-onboarding.md) to self-train and update knowledge, with the support of a buddy who will be available throughout the process.
+During the [onboarding period](/procedures/employee-onboarding.md) the level ofto self-train and update knowledge, with the support of a buddy who will be available throughout the process.
 
 The ideal approach is to have an interactive, guided and pre-designed path, based on a "Getting Started" approach, that provides insights for further exploration without going too deep.
 
 That's what this page is: it lists all core skills, split into modules, each of which provides one or more links to educational materials and hands-on tutorials <sup><a href="#fn1">1</a></sup>.
 
-> **NOTE**: See [Assessing Core Skills]() section to learn how to access core skills, then head back to this page to create a personalized training plan based on the results.
+> **NOTE**: See [Assessing Core Skills](/procedures/assessing-core-skills) section to learn how to access core skills, then head back to this page to create a personalized training plan based on the results.
 
-## Command line / Shell
+<style>
+    #table-styler-code-skills table th:first-of-type { width: 25%;}
+    #table-styler-code-skills table th:nth-of-type(2) { width: 75%; }
+</style>
+<div id="table-styler-code-skills">
 
-**Estimated Time**: 24h  
-
-### Basics
-
-The command line is one of the tools we use extensively to standardize the developer experience and automatically share secrets and settings across all projects.
-
-| Resources | |
+| Basics | |
 |---|---|
-| **Documentation** | [Makefile Tutorial](https://makefiletutorial.com/) |
-| **Hands-on** | [The Shell (LinuxJourney)](https://linuxjourney.com/lesson/the-shell) |
-| | [Output redirection (LinuxJourney)](https://linuxjourney.com/lesson/stdout-standard-out-redirect) |
-| | [Bash Crawl (SlackerMedia)](https://gitlab.com/slackermedia/bashcrawl#try-it-online-with-mybinder) |
+| Command line / Shell | The command line is one of the tools we use extensively to standardize the developer experience and automatically share secrets and settings across all projects. |
+| Security | Security starts from our tools and habits. Credentials management, encryption, secure authentication, and other foundamental topics must be clear to everyone, so they can click in place with our practices. |
+| Networking| We develop online software and services. Having a clear understanding of the foundational protocols we use every day enables informed decisions and quicker problem-solving. |
 
-### Security
-
-Any credentials (API keys, passwords, etc.) should not be committed to the project and should not be present on the local disk, especially if it is not encrypted. Credentials should only be saved within secure tools provided by our platforms, such as GitLab/GitHub.
-
-| Resources | |
+| Tools | |
 |---|---|
-| **Documentation** | [Concise Guide for Developing More Secure Software (OpenSSF)](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Developing-More-Secure-Software.md#readme) |
-| | [Concise Guide for Evaluating Open Source Software (OpenSSF)](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Evaluating-Open-Source-Software.md#readme) |
-| | [The Secure Software Factory (CNCF Tag Security Whitepaper)](https://github.com/cncf/tag-security/blob/main/supply-chain-security/secure-software-factory/Secure_Software_Factory_Whitepaper.pdf) |
-| **Hands-on** | [Developing Secure Software (LFD121)](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/) <sup><a href="#fn2">2</a></sup> |
+| YAML | _Yet Another Markup Language_, this declarative, structured JSON alternative is easy to read and write for humans and easy to parse and abstract for a machine. These qualities made it almost ubiquitous. It's syntax is very simple but powerful. |
+| Git | Git is the industry standard CVS and it's at the base of every project we develop. Git is highly intertwined with our automation, so it's vital to understand how it works, and how the various aspects of the workflow impact our delivery. |
+| GitHub Copilot | A context-aware, AI-based tool that helps writing code faster. When used correctly, it allows to optimize repetitive tasks and quickly create prototypes and blueprints. |
 
-### Git
-
-Git is the fundamental tool we use to work on any development project, both internal and external.
-
-| Resources | |
+| DevOps | |
 |---|---|
-| **Documentation** | [Git Workflow](https://playbook.sparkfabrik.com/procedures/git-workflow) |
-| | [Gitlab Flow](https://docs.gitlab.com/ee/topics/gitlab_flow.html) |
-| **Hands-on** | [Learn Git Branching](https://learngitbranching.js.org/) |
+| Docker and Docker Compose | Our local stack always includes one or more containers with the services that compose the application, typically reflecting the production architecture. We use Docker alongside the snack-sized orchestrator Docker Compose to automate the management of different local development environments for our projects. |
+| Kubernetes | The most famous FOSS container orchestrator, Kubernetes is our preferred infrastructure to manage multi-service applications. You may not be among those who use it daily but grasping the basic concepts is important because - if nothing else - our internal infrastructure is based on it. |
+| CI/CD | We work in a regime of Continuous Integration and our delivery is always automated (Continuous whenever possible, depending on the project. We mainly use Gitlab and GitHub automation tools, like Pipelines and Actions, both to be understood in their basics. |
+</div>
 
+> TODO: From here!
 
-## DevOps
-
-**Estimated Time**: 18h  
-
-### Docker e Docker Compose
-
-Our local stack always includes one or more containers with the services that compose the application, typically reflecting the production architecture.
-
-| Resources | |
-|---|---|
-| **Documentation** | [Docker - Zero to Hero (TechWorld with Nana - YouTube)](https://youtu.be/3c-iBn73dDE) |
-| | [Docker-Compose Tutorial (TechWorld with Nana - YouTube)](https://youtu.be/MVIcrmeV_6c) |
-| **Hands-on** | [Docker 101 Tutorial](https://www.docker.com/101-tutorial/) |
-
-### Kubernetes
-
-Our preferred infrastructure to manage multi-service applications.
-
-| Resources | |
-|---|---|
-| **Documentation** | [The Illustrated Childrens Guide to Kubernetes (Italian)](https://www.cncf.io/wp-content/uploads/2021/11/The-Illustrated-Childrens-Guide-to-Kubernetes-Italian-Spark.pdf) |
-| **Hands-on** | [Kubernetes (KillerCoda)](https://killercoda.com/kubernetes) <sup><a href="#fn3">3</a></sup> |
-
-### YAML
-
-The format is used to describe almost all cloud-native services, such as Docker Compose and Kubernetes.
-
-| Resources | |
-|---|---|
-| **Documentation** | [YAML Syntax (Ansible Documentation)](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html) |
-| **Hands-on** | [YAML Tutorial - Everything you need get started (CloudBees)](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started) |
-
-
-## Continuous Integration (CI/CD)
-
-**Estimated Time**: 8h  
-
-### GitLab & GitHub
-
-These are our reference tools to manage repositories, projects (agile boards), and continuous integration with automated pipelines.
-
-| Resources | |
-|---|---|
-| **Documentation** | [Introduction to CI (GitLab Documentation)](https://docs.gitlab.com/ee/ci/introduction/) |
-| | [Create and run your first GitLab CI/CD pipeline (GitLab Tutorial)](https://docs.gitlab.com/ee/ci/quick_start/) |
-| | [GitLab CI/CD in one hour (TechWorld with Nana - YouTube)](https://youtu.be/qP8kir2GUgo) |
-| | [Understanding GitHub Actions (GitHub Docs)](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) |
-| **Hands-on** | [Become a GitHub Actions Hero](https://github-actions-hero.vercel.app/) |
-
-## Bonus track - GitHub Copilot
-
-**Estimated Time**:  1h to activate and test it out.
-
-A context-aware, AI-based tool that helps writing code faster. When used correctly, it allows to optimize repetitive tasks and quickly create prototypes and blueprints.
-
-See [GitHub Copilot](https://playbook.sparkfabrik.com/tools-and-policies/github-copilot) page in the _Tools and Policies_ section.
 
 ---
 
@@ -119,7 +51,7 @@ There are several variables that can influence the schedule for study hours, lik
 Therefore, each team-leader is free to decide how to plan the training with the new employee, as long as it's done within the first two months.
 
 For example, imagining that the training path takes up all 40 hours, they can decide to spend 10 consecutive afternoons for the first 10 working days. Or they may want to seize some slack the project may grant for the first week to go all-in and spend it all learning the basics.  
-Again, they may decide di spend a couple days on the most relevant knowledge gaps, and postpone after a couple weeks the refresh of concepts that are already there.
+Again, they may decide to spend a couple days on the most relevant knowledge gaps, and postpone after a couple weeks the refresh of concepts that are already there.
 
 | When                             | What                                                    | Who              |
 |----------------------------------|---------------------------------------------------------|------------------|
@@ -135,47 +67,6 @@ Again, they may decide di spend a couple days on the most relevant knowledge gap
 | **End of second month**          |                                                         |                  |
 |                                  | Review and evaluate training results                    | HR, TL, newentry |
 
-To help prioritizing and planning the necessary training, we hereby provide the list of modules, ordered by priority, for each company area.
-
-### Web Development
-
-| Module               | Topic                    |
-|----------------------|--------------------------|
-| Command-line / Shell | Basics                   |
-| Command-line / Shell | Git                      |
-| DevOps               | Docker & Docker compose  |
-| Command-line / Shell | Security                 |
-| DevOps               | YAML                     |
-| CI/CD                | GitLab & GitHub (basics) |
-| DevOps               | Kubernetes (basics)      |
-
-### Mobile Development
-
-| Module               | Topic                    |
-|----------------------|--------------------------|
-| Command-line / Shell | Basics                   |
-| Command-line / Shell | Git                      |
-| DevOps               | YAML                     |
-| CI/CD                | GitLab & GitHub (basics) |
-| Command-line / Shell | Security                 |
-| DevOps               | Docker & Docker compose  |
-| DevOps               | Kubernetes (basics)      |
-
-### Platform
-
-| Module               | Topic                   |
-|----------------------|-------------------------|
-| Command-line / Shell | Basics                  |
-| Command-line / Shell | Git                     |
-| CI/CD                | GitLab & GitHub         |
-| Command-line / Shell | Security                |
-| DevOps               | Docker & Docker compose |
-| DevOps               | YAML                    |
-| DevOps               | Kubernetes              |
-
-
 ---
 
-<small><a name="fn1">1</a>: In addition, <a href="/resources/training-resources">this page</a> explains how to access educational video courses that may be of interest to strengthen hard skills on specific technologies and tools.</small><br>
-<small><a name="fn2">2</a>: The "Developing Secure Software" course (LFD121) is considered a long-term goal to be completed within the first 12 months after the probationary period.</small><br>
-<small><a name="fn3">3</a>: Limit hands-on exercices to “Pod Intro”, “Deployment Basics” and “A Playground” sections.</small>
+<small><a name="fn1">1</a>: In addition, <a href="/resources/training-resources#other-training-resources">this page</a> explains how to access educational video courses that may be of interest to strengthen hard skills on specific technologies and tools.</small><br>

--- a/content/working-at-sparkfabrik/core-skills.md
+++ b/content/working-at-sparkfabrik/core-skills.md
@@ -42,7 +42,7 @@ Anyway, during the [very first days of onboarding](/procedures/employee-onboardi
 |---|---|
 | **Docker and Docker Compose** | Our local stack always includes one or more containers with the services that compose the application, typically reflecting the production architecture. We use Docker alongside the snack-sized orchestrator Docker Compose to automate the management of different local development environments for our projects. |
 | **Kubernetes** | The most famous FOSS container orchestrator, Kubernetes is our preferred infrastructure to manage multi-service applications. You may not be among those who use it daily but grasping the basic concepts is important because - if nothing else - our internal infrastructure is based on it. |
-| **CI/CD** | We work in a regime of Continuous Integration and our delivery is always automated (Continuous whenever possible, depending on the project. We mainly use Gitlab and GitHub automation tools, like Pipelines and Actions, both to be understood in their basics. |
+| **CI/CD** | We work in a regime of Continuous Integration and our delivery is always automated (Continuous whenever possible, depending on the project). We mainly use GitLab and GitHub automation tools, like GitLab CI/CD and Actions, both to be understood in their basics. |
 
 </div>
 

--- a/content/working-at-sparkfabrik/core-skills.md
+++ b/content/working-at-sparkfabrik/core-skills.md
@@ -5,178 +5,142 @@ Sort: 30
 
 **Core skills** are those shared across all teams, whether Platform or Development teams, and they form the foundation we expect all professionals at SparkFabrik to have.
 
-The purpose of this document is to list the training resources to consolidate the key competencies we recognize in every professional. 
+The purpose of this document is to list the training resources to consolidate the key competencies we recognize in every professional.
 
-The training resources will be useful during the onboarding period at the company to self-train and update knowledge, with the support of a "buddy" who will be available throughout the process. 
+The training resources will be useful during the [onboarding period](/procedures/employee-onboarding.md) to self-train and update knowledge, with the support of a buddy who will be available throughout the process.
 
-The ideal approach is to have an interactive, guided path already designed with a "Getting Started" perspective that provides insights for further exploration without going “too deep”.
+The ideal approach is to have an interactive, guided and pre-designed path, based on a "Getting Started" approach, that provides insights for further exploration without going too deep.
 
-This page lists all core skills, split into modules, each of which concludes with a simple self-assessment to be completed individually or with the support of the buddy, who could help to understand if the key-concepts are well understood. 
+That's what this page is: it lists all core skills, split into modules, each of which provides one or more links to educational materials and hands-on tutorials <sup><a href="#fn1">1</a></sup>.
 
-For each identified core skill, we provide one or more links to educational materials and hands-on tutorials.
+> **NOTE**: See [Assessing Core Skills]() section to learn how to access core skills, then head back to this page to create a personalized training plan based on the results.
 
-## General Resources
+## Command line / Shell
 
-In our Playbook, you can find a list of educational materials in the form of online courses available on the most popular training platforms. The [dedicated page](https://playbook.sparkfabrik.com/resources/training-resources) also contains information on how to access this material.
+**Estimated Time**: 24h  
+**Assessment**: `TBD`
 
+### Basics
 
-## Core modules
+The command line is one of the tools we use extensively to standardize the developer experience and automatically share secrets and settings across all projects.
 
----
+| Resources | |
+|---|---|
+| **Documentation** | [Makefile Tutorial](https://makefiletutorial.com/) |
+| **Hands-on** | [The Shell (LinuxJourney)](https://linuxjourney.com/lesson/the-shell) |
+| | [Output redirection (LinuxJourney)](https://linuxjourney.com/lesson/stdout-standard-out-redirect) |
+| | [Bash Crawl (SlackerMedia)](https://gitlab.com/slackermedia/bashcrawl#try-it-online-with-mybinder) |
 
-### Command-line / Shell
-
-#### Basics
-
-The command-line is one of the tools we use extensively to standardize the developer experience and automatically share secrets and settings across all projects.
-
-##### Documentation
-
-* Makefile: [https://makefiletutorial.com/](https://makefiletutorial.com/)
-
-##### Hands-on
-
-* [https://linuxjourney.com/lesson/the-shell](https://linuxjourney.com/lesson/the-shell)
-* [https://linuxjourney.com/lesson/stdout-standard-out-redirect](https://linuxjourney.com/lesson/stdout-standard-out-redirect)
-* [https://gitlab.com/slackermedia/bashcrawl#try-it-online-with-my binder](https://gitlab.com/slackermedia/bashcrawl#try-it-online-with-mybinder)
-
-
-#### Security
+### Security
 
 Any credentials (API keys, passwords, etc.) should not be committed to the project and should not be present on the local disk, especially if it is not encrypted. Credentials should only be saved within secure tools provided by our platforms, such as GitLab/GitHub.
 
-##### Documentation
+| Resources | |
+|---|---|
+| **Documentation** | [Concise Guide for Developing More Secure Software (OpenSSF)](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Developing-More-Secure-Software.md#readme) |
+| | [Concise Guide for Evaluating Open Source Software (OpenSSF)](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Evaluating-Open-Source-Software.md#readme) |
+| | [The Secure Software Factory (CNCF Tag Security Whitepaper)](https://github.com/cncf/tag-security/blob/main/supply-chain-security/secure-software-factory/Secure_Software_Factory_Whitepaper.pdf) |
+| **Hands-on** | [Developing Secure Software (LFD121)](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/) <sup><a href="#fn2">2</a></sup> |
 
-* OpenSSF: [Concise Guide for Developing More Secure Software](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Developing-More-Secure-Software.md#readme)
-* OpenSSF: [Concise Guide for Evaluating Open Source Software](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Evaluating-Open-Source-Software.md#readme)
-* CNCF Tag Security: [The Secure Software Factory](https://github.com/cncf/tag-security/blob/main/supply-chain-security/secure-software-factory/Secure_Software_Factory_Whitepaper.pdf) (whitepaper)
-
-##### Hands-on
-
-* [Developing Secure Software (LFD121)](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/) (14-18h)
-
-_Note:_ The "Developing Secure Software" course (LFD121) is considered a long-term goal to be completed within the first 12 months after the probationary period.
-
-#### Git
+### Git
 
 Git is the fundamental tool we use to work on any development project, both internal and external.
 
-##### Documentation
-
-* Git workflow: [https://playbook.sparkfabrik.com/procedures/git-workflow](https://playbook.sparkfabrik.com/procedures/git-workflow)
-* [https://docs.gitlab.com/ee/topics/gitlab_flow.html](https://docs.gitlab.com/ee/topics/gitlab_flow.html)
-
-##### Hands-on
-
-* [https://learngitbranching.js.org/](https://learngitbranching.js.org/)
+| Resources | |
+|---|---|
+| **Documentation** | [Git Workflow](https://playbook.sparkfabrik.com/procedures/git-workflow) |
+| | [Gitlab Flow](https://docs.gitlab.com/ee/topics/gitlab_flow.html) |
+| **Hands-on** | [Learn Git Branching](https://learngitbranching.js.org/) |
 
 
-#### Timing and Assessment
+## DevOps
 
-_Estimated Time:_ 24h
+**Estimated Time**: 18h  
+**Assessment**: TBD
 
-Assessment: SparkFabrik will provide a private repository to clone, containing an application with some errors in build and startup scripts, and security practices. The candidate should correct these errors to make the application run.
-
----
-
-### DevOps
-
-
-#### Docker e Docker Compose
+### Docker e Docker Compose
 
 Our local stack always includes one or more containers with the services that compose the application, typically reflecting the production architecture.
 
-##### Documentation
+| Resources | |
+|---|---|
+| **Documentation** | [Docker - Zero to Hero (TechWorld with Nana - YouTube)](https://youtu.be/3c-iBn73dDE) |
+| | [Docker-Compose Tutorial (TechWorld with Nana - YouTube)](https://youtu.be/MVIcrmeV_6c) |
+| **Hands-on** | [Docker 101 Tutorial](https://www.docker.com/101-tutorial/) |
 
-* [https://youtu.be/3c-iBn73dDE](https://youtu.be/3c-iBn73dDE)
-* [https://youtu.be/MVIcrmeV_6c](https://youtu.be/MVIcrmeV_6c) 
-
-##### Hands-on
-
-* [https://www.docker.com/101-tutorial/](https://www.docker.com/101-tutorial/)
-
-#### Kubernetes
+### Kubernetes
 
 Our preferred infrastructure to manage multi-service applications.
 
-##### Documentation
+| Resources | |
+|---|---|
+| **Documentation** | [The Illustrated Childrens Guide to Kubernetes (Italian)](https://www.cncf.io/wp-content/uploads/2021/11/The-Illustrated-Childrens-Guide-to-Kubernetes-Italian-Spark.pdf) |
+| **Hands-on** | [Kubernetes (KillerCoda)](https://killercoda.com/kubernetes) <sup><a href="#fn3">3</a></sup> |
 
-* [https://www.cncf.io/wp-content/uploads/2021/11/The-Illustrated-Childrens-Guide-to-Kubernetes-Italian-Spark.pdf](https://www.cncf.io/wp-content/uploads/2021/11/The-Illustrated-Childrens-Guide-to-Kubernetes-Italian-Spark.pdf)
-
-##### Hands-on
-
-* [https://killercoda.com/kubernetes](https://killercoda.com/kubernetes) - “Pod Intro”, “Deployment Basics” and “A Playground”
-
-
-#### YAML
+### YAML
 
 The format is used to describe almost all cloud-native services, such as Docker Compose and Kubernetes.
 
-##### Documentation
-
-* [https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html)
-
-##### Hands-on
-
-* [https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started)
+| Resources | |
+|---|---|
+| **Documentation** | [YAML Syntax (Ansible Documentation)](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html) |
+| **Hands-on** | [YAML Tutorial - Everything you need get started (CloudBees)](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started) |
 
 
-#### Timing and Assessment
+## Continuous Integration (CI/CD)
 
-_Estimated Time:_  18h
+**Estimated Time**: 8h  
+**Assessment**: TBD
 
-_Assessment:_ SparkFabrik will provide a private repository to create a mini-project with Docker and Kubernetes (kind), hypothetically a web app with an nginx server.
-
-
-### Continuous Integration (CI/CD)
-
-
-#### GitLab & GitHub
+### GitLab & GitHub
 
 These are our reference tools to manage repositories, projects (agile boards), and continuous integration with automated pipelines.
 
-##### Documentation
+| Resources | |
+|---|---|
+| **Documentation** | [Introduction to CI (GitLab Documentation)](https://docs.gitlab.com/ee/ci/introduction/) |
+| | [Create and run your first GitLab CI/CD pipeline (GitLab Tutorial)](https://docs.gitlab.com/ee/ci/quick_start/) |
+| | [GitLab CI/CD in one hour (TechWorld with Nana - YouTube)](https://youtu.be/qP8kir2GUgo) |
+| | [Understanding GitHub Actions (GitHub Docs)](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) |
+| **Hands-on** | [Become a GitHub Actions Hero](https://github-actions-hero.vercel.app/) |
 
-* [https://docs.gitlab.com/ee/ci/introduction/](https://docs.gitlab.com/ee/ci/introduction/)
-* [https://docs.gitlab.com/ee/ci/quick_start/](https://docs.gitlab.com/ee/ci/quick_start/)
-* [https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions)
-* [https://youtu.be/qP8kir2GUgo](https://youtu.be/qP8kir2GUgo)
+## Bonus track - GitHub Copilot
 
-##### Hands-on
+**Estimated Time**:  1h to activate and test it out.
 
-* [https://github-actions-hero.vercel.app/](https://github-actions-hero.vercel.app/)
+A context-aware, AI-based tool that helps writing code faster. When used correctly, it allows to optimize repetitive tasks and quickly create prototypes and blueprints.
 
-#### Timing and Assessment
+See [GitHub Copilot](https://playbook.sparkfabrik.com/tools-and-policies/github-copilot) page in the _Tools and Policies_ section.
 
-_Estimated Time:_ 8h
+---
 
-Assessment: SparkFabrik will provide a private repository with CI and job templates, and tasks such as adding a new job, retrieving logs, or fixing non-functioning jobs.
+## How to plan the training on core skills
 
-### Bonus: GitHub Copilot
+During the very first days in SparkFabrik, the confidence degree with the basic concepts of the necessary core skills will be [assessed by a buddy](). Depending on the findings, **a maximum of 40 working hours** will be allocated **within the first two two months** for the new employee to learn the key-concepts.
 
-A tool that utilizes AI to auto-complete code more intelligently. When used correctly, it allows us to optimize repetitive tasks and quickly create prototypes and blueprints.
+There are several variables that can influence the schedule for study hours, like expertise, background, or learning speed of the new entry, project deadlines, needs, and organization, customer-related constraints, etc.  
+Therefore, each team-leader is free to decide how to plan the training with the new employee, as long as it's done within the first two months.
 
-Documentation
+For example, imagining that the training path takes up all 40 hours, they can decide to spend 10 consecutive afternoons for the first 10 working days. Or they may want to seize some slack the project may grant for the first week to go all-in and spend it all learning the basics.  
+Again, they may decide di spend a couple days on the most relevant knowledge gaps, and postpone after a couple weeks the refresh of concepts that are already there.
 
-[https://playbook.sparkfabrik.com/tools-and-policies/github-copilot](https://playbook.sparkfabrik.com/tools-and-policies/github-copilot)
+| When                             | What                                                    | Who              |
+|----------------------------------|---------------------------------------------------------|------------------|
+| **From 2nd day of onboarding**   |                                                         |                  |
+|                                  | Assess required core skills and training needs          | TL and new entry |
+|                                  | Create a proposal to allocate training hours            | TL               |
+|                                  | Planning review and approval                            | Ops and/or CTO   |
+| **During first month**           |                                                         |                  |
+|                                  | Implement the training plan                             | New entry        |
+| **During second month**          |                                                         |                  |
+|                                  | During planned 1-on-1, gets feedback about the progress | HR               |
+|                                  | Continuous evaluation and process updates               | HR, TL, newentry |
+| **End of second month**          |                                                         |                  |
+|                                  | Review and evaluate training results                    | HR, TL, newentry |
 
-_Estimated Time: _1h
+To help prioritizing and planning the necessary training, we hereby provide the list of modules, ordered by priority, for each company area.
 
-
-### Summary
-
-| Module                             | Suggested Time (hours)     |
-|------------------------------------|----------------------------|
-| Command-line / Shell               | 50% on total hours         |
-| DevOps                             | 35% on total hours         |
-| Continuous Integration (CI/CD)     | 15% on total hours         |
-| Total hours                        | 40                         |
-
-
-#### Team Tracks 
-
-
-##### Developers
+### Web Development
 
 | Module               | Topic                    |
 |----------------------|--------------------------|
@@ -188,9 +152,7 @@ _Estimated Time: _1h
 | CI/CD                | GitLab & GitHub (basics) |
 | DevOps               | Kubernetes (basics)      |
 
-
-
-##### Mobile
+### Mobile Development
 
 | Module               | Topic                    |
 |----------------------|--------------------------|
@@ -202,8 +164,7 @@ _Estimated Time: _1h
 | DevOps               | Docker & Docker compose  |
 | DevOps               | Kubernetes (basics)      |
 
-
-##### Platform
+### Platform
 
 | Module               | Topic                   |
 |----------------------|-------------------------|
@@ -218,39 +179,6 @@ _Estimated Time: _1h
 
 ---
 
-##### How to allocate study hours
-
-| When                                          | What                                                                   | Who              |
-|-----------------------------------------------|------------------------------------------------------------------------|------------------|
-|                                               | Assess required core skills and training needs (checklist)             | TL and new entry |
-| From the 2nd day of onboarding                | Create a proposal to allocate study hours (*)                          | TL               |
-|                                               | Revisione e approvazione del piano                                     | Ops and/or CTO   |
-| During first month                            | Implement the study plan                                               | New entry        |
-| Second month                                  | Individual meetings (1:1) to collect feedback on the training progress | HR               |
-|                                               | Continuous evaluation and process updates                              | HR, TL, newentry |
-
-
-(*) There are several variables that can influence the allocation of study hours:
-
-
-* Expertise and background of the new entry 
-* Project (deadlines, needs, organization, contact with the client) 
-* Learning speed 
-* … what else? TODO
-
-**Total hours Available: **40 hours
-
-**Examples of study hour allocation:** 
-
-_Example 1_
-
-_40 hours to allocate _
-
-_10 half-days consecutively for the first 10 working days_
-
-_Example 2_
-
-_40 hours to allocate _
-
-
-## _2 half-days per week for 5 weeks_
+<small><a name="fn1">1</a>: In addition, <a href="/resources/training-resources">this page</a> explains how to access educational video courses that may be of interest to strengthen hard skills on specific technologies and tools.</small><br>
+<small><a name="fn2">2</a>: The "Developing Secure Software" course (LFD121) is considered a long-term goal to be completed within the first 12 months after the probationary period.</small><br>
+<small><a name="fn3">3</a>: Limit hands-on exercices to “Pod Intro”, “Deployment Basics” and “A Playground” sections.</small>

--- a/content/working-at-sparkfabrik/core-skills.md
+++ b/content/working-at-sparkfabrik/core-skills.md
@@ -18,7 +18,6 @@ That's what this page is: it lists all core skills, split into modules, each of 
 ## Command line / Shell
 
 **Estimated Time**: 24h  
-**Assessment**: `TBD`
 
 ### Basics
 
@@ -56,7 +55,6 @@ Git is the fundamental tool we use to work on any development project, both inte
 ## DevOps
 
 **Estimated Time**: 18h  
-**Assessment**: TBD
 
 ### Docker e Docker Compose
 
@@ -90,7 +88,6 @@ The format is used to describe almost all cloud-native services, such as Docker 
 ## Continuous Integration (CI/CD)
 
 **Estimated Time**: 8h  
-**Assessment**: TBD
 
 ### GitLab & GitHub
 

--- a/content/working-at-sparkfabrik/core-skills.md
+++ b/content/working-at-sparkfabrik/core-skills.md
@@ -3,15 +3,22 @@ Description: Basic technical skills by department
 Sort: 30
 */
 
-**Core skills** are shared across all teams, whether Platform or Development ones, and they form the foundation we expect all professionals at SparkFabrik to have.
+When we name **Core Skills** we are talking about a set of fundamental technical competencies shared across all teams, whether they are Development teams or Platform teams. It is essential that every professional in the company has at least a foundational understanding and a high-level comprehension of these topics, as they are frequently encountered in daily work.
 
-During the [onboarding period](/procedures/employee-onboarding.md) the level ofto self-train and update knowledge, with the support of a buddy who will be available throughout the process.
+We have identified a set of [training resources](/resources/training-resources#core-skills-training-resources) which offer an interactive, guided and pre-designed path, based on a _getting started_ approach, that provides insights for further exploration without going too deep.
 
-The ideal approach is to have an interactive, guided and pre-designed path, based on a "Getting Started" approach, that provides insights for further exploration without going too deep.
+Acquiring the necessary set of information should take approximately 40 hours, and we strongly suggest anyone (old or new), as well as who want to apply for a technical position to invest a bit in learning them.
 
-That's what this page is: it lists all core skills, split into modules, each of which provides one or more links to educational materials and hands-on tutorials <sup><a href="#fn1">1</a></sup>.
+Anyway, during the [very first days of onboarding](/procedures/employee-onboarding.md), the team leader or buddy [will quickly assess the new colleague's confidence level with these topics](/procedures/assessing-core-skills). They will then jot down a self-training program to be undertaken within the end of the probation period.
 
-> **NOTE**: See [Assessing Core Skills](/procedures/assessing-core-skills) section to learn how to access core skills, then head back to this page to create a personalized training plan based on the results.
+> **For the Team Leader or buddy**:
+>
+> The following sections offer a guided procedure to conduct accessments and create learning plans.
+>
+> * [Assessing Core Skills](/procedures/assessing-core-skills)
+> * [Plan training on Core Skills](/procedures/assessing-core-skills#plan-the-training-on-core-skills)
+
+## Technical Core Skills
 
 <style>
     #table-styler-code-skills table th:first-of-type { width: 25%;}
@@ -21,52 +28,23 @@ That's what this page is: it lists all core skills, split into modules, each of 
 
 | Basics | |
 |---|---|
-| Command line / Shell | The command line is one of the tools we use extensively to standardize the developer experience and automatically share secrets and settings across all projects. |
-| Security | Security starts from our tools and habits. Credentials management, encryption, secure authentication, and other foundamental topics must be clear to everyone, so they can click in place with our practices. |
-| Networking| We develop online software and services. Having a clear understanding of the foundational protocols we use every day enables informed decisions and quicker problem-solving. |
+| **Command line / Shell** | The command line is one of the tools we use extensively to standardize the developer experience and automatically share secrets and settings across all projects. |
+| **Security** | Security starts from our tools and habits. Credentials management, encryption, secure authentication, and other foundamental topics must be clear to everyone, so they can click in place with our practices. |
+| **Networking** | We develop online software and services. Having a clear understanding of the foundational protocols we use every day enables informed decisions and quicker problem-solving. |
 
 | Tools | |
 |---|---|
-| YAML | _Yet Another Markup Language_, this declarative, structured JSON alternative is easy to read and write for humans and easy to parse and abstract for a machine. These qualities made it almost ubiquitous. It's syntax is very simple but powerful. |
-| Git | Git is the industry standard CVS and it's at the base of every project we develop. Git is highly intertwined with our automation, so it's vital to understand how it works, and how the various aspects of the workflow impact our delivery. |
-| GitHub Copilot | A context-aware, AI-based tool that helps writing code faster. When used correctly, it allows to optimize repetitive tasks and quickly create prototypes and blueprints. |
+| **YAML** | _Yet Another Markup Language_, this declarative, structured JSON alternative is easy to read and write for humans and easy to parse and abstract for a machine. These qualities made it almost ubiquitous. It's syntax is very simple but powerful. |
+| **Git** | Git is the industry standard CVS and it's at the base of every project we develop. Git is highly intertwined with our automation, so it's vital to understand how it works, and how the various aspects of the workflow impact our delivery. |
+| **GitHub Copilot** | A context-aware, AI-based tool that helps writing code faster. When used correctly, it allows to optimize repetitive tasks and quickly create prototypes and blueprints. |
 
 | DevOps | |
 |---|---|
-| Docker and Docker Compose | Our local stack always includes one or more containers with the services that compose the application, typically reflecting the production architecture. We use Docker alongside the snack-sized orchestrator Docker Compose to automate the management of different local development environments for our projects. |
-| Kubernetes | The most famous FOSS container orchestrator, Kubernetes is our preferred infrastructure to manage multi-service applications. You may not be among those who use it daily but grasping the basic concepts is important because - if nothing else - our internal infrastructure is based on it. |
-| CI/CD | We work in a regime of Continuous Integration and our delivery is always automated (Continuous whenever possible, depending on the project. We mainly use Gitlab and GitHub automation tools, like Pipelines and Actions, both to be understood in their basics. |
+| **Docker and Docker Compose** | Our local stack always includes one or more containers with the services that compose the application, typically reflecting the production architecture. We use Docker alongside the snack-sized orchestrator Docker Compose to automate the management of different local development environments for our projects. |
+| **Kubernetes** | The most famous FOSS container orchestrator, Kubernetes is our preferred infrastructure to manage multi-service applications. You may not be among those who use it daily but grasping the basic concepts is important because - if nothing else - our internal infrastructure is based on it. |
+| **CI/CD** | We work in a regime of Continuous Integration and our delivery is always automated (Continuous whenever possible, depending on the project. We mainly use Gitlab and GitHub automation tools, like Pipelines and Actions, both to be understood in their basics. |
+
 </div>
 
-> TODO: From here!
-
-
----
-
-## How to plan the training on core skills
-
-During the very first days in SparkFabrik, the confidence degree with the basic concepts of the necessary core skills will be [assessed by a buddy](). Depending on the findings, **a maximum of 40 working hours** will be allocated **within the first two two months** for the new employee to learn the key-concepts.
-
-There are several variables that can influence the schedule for study hours, like expertise, background, or learning speed of the new entry, project deadlines, needs, and organization, customer-related constraints, etc.  
-Therefore, each team-leader is free to decide how to plan the training with the new employee, as long as it's done within the first two months.
-
-For example, imagining that the training path takes up all 40 hours, they can decide to spend 10 consecutive afternoons for the first 10 working days. Or they may want to seize some slack the project may grant for the first week to go all-in and spend it all learning the basics.  
-Again, they may decide to spend a couple days on the most relevant knowledge gaps, and postpone after a couple weeks the refresh of concepts that are already there.
-
-| When                             | What                                                    | Who              |
-|----------------------------------|---------------------------------------------------------|------------------|
-| **From 2nd day of onboarding**   |                                                         |                  |
-|                                  | Assess required core skills and training needs          | TL and new entry |
-|                                  | Create a proposal to allocate training hours            | TL               |
-|                                  | Planning review and approval                            | Ops and/or CTO   |
-| **During first month**           |                                                         |                  |
-|                                  | Implement the training plan                             | New entry        |
-| **During second month**          |                                                         |                  |
-|                                  | During planned 1-on-1, gets feedback about the progress | HR               |
-|                                  | Continuous evaluation and process updates               | HR, TL, newentry |
-| **End of second month**          |                                                         |                  |
-|                                  | Review and evaluate training results                    | HR, TL, newentry |
-
----
-
-<small><a name="fn1">1</a>: In addition, <a href="/resources/training-resources#other-training-resources">this page</a> explains how to access educational video courses that may be of interest to strengthen hard skills on specific technologies and tools.</small><br>
+* [Click here to learn how to access your proficiency in the Core Skills.](/procedures/assessing-core-skills)
+* [Click here for a list of all the training material related to the Core Skills.](/resources/training-resources#core-skills-training-resources)


### PR DESCRIPTION
This brings the internal document about core skills and onboarding training planning to the Playbook.

The document will roughly be divided in two pages:

- One in the `Resources` section, with the list of training resources, separated by macro-topic.
- One in the `Working at SparkFabrik` or `Guides` sections (still deciding) with the instruction about assessment and planning the training

I'll also link the whole thing to the onboarding checklist page and add a cross-link between the existing training resources page and the new one for the core skills.