### PR TITLE
refs #200 restore headings ids

### DIFF
--- a/custom/config.js
+++ b/custom/config.js
@@ -55,6 +55,10 @@ var config = {
   // all categories or files that do not specify ShowOnMenu meta property will be shown
   show_on_menu_default: true,
 
+  // When set to true, an ID is generated for all the H level elements
+  // to be used as anchors.
+  headers_id: true,
+
   // Theme (see top of file)
   theme_dir,
   theme_name,

--- a/custom/package.json
+++ b/custom/package.json
@@ -9,7 +9,8 @@
     "check": "markdown-link-validator -q -e -o -c 403 --ignorePatternsFrom ./content/.mlvignore ./content",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "cd .. && husky install custom/.husky",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "generate-patch": "patch-package raneto"
   },
   "license": "https://creativecommons.org/licenses/by-sa/4.0/",
   "dependencies": {

--- a/custom/patches/raneto+0.17.5.patch
+++ b/custom/patches/raneto+0.17.5.patch
@@ -30,8 +30,21 @@ index 52673cf..8bff5b4 100644
          active: activePageSlug.trim() === `/${slug}`,
          sort: pageSort,
        };
+diff --git a/node_modules/raneto/app/core/page.js b/node_modules/raneto/app/core/page.js
+index 6bcc421..ca00553 100644
+--- a/node_modules/raneto/app/core/page.js
++++ b/node_modules/raneto/app/core/page.js
+@@ -26,7 +26,7 @@ async function handler(filePath, config) {
+     // Render Markdown
+     marked.use({
+       mangle: false,
+-      headerIds: false,
++      headerIds: config.headers_id ?? true,
+     });
+     const body = marked(content);
+     const title = meta.title ? meta.title : contentProcessors.slugToTitle(slug);
 diff --git a/node_modules/raneto/app/routes/wildcard.route.js b/node_modules/raneto/app/routes/wildcard.route.js
-index b876048..1998cd1 100644
+index b876048..256463d 100644
 --- a/node_modules/raneto/app/routes/wildcard.route.js
 +++ b/node_modules/raneto/app/routes/wildcard.route.js
 @@ -1,5 +1,6 @@
@@ -41,7 +54,15 @@ index b876048..1998cd1 100644
  var fs = require('fs-extra');
  const { marked } = require('marked');
  var toc = require('markdown-toc');
-@@ -98,7 +99,16 @@ function route_wildcard(config) {
+@@ -91,14 +92,23 @@ function route_wildcard(config) {
+         // Render Markdown
+         marked.use({
+           mangle: false,
+-          headerIds: false,
++          headerIds: config.headers_id ?? true,
+         });
+         content = marked(content);
+       }
  
        var pageList = remove_image_content_directory(
          config,

--- a/custom/themes/spark-playbook/package-lock.json
+++ b/custom/themes/spark-playbook/package-lock.json
@@ -5910,9 +5910,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.28",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
-      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
# Added

- a custom property in config.js to optionally make Raneto add the ID property in the headings inside the content of the page. If no option is set the ids are visible by default. 

