### PR TITLE
refs #000: Update to Docker Compose V2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,17 @@
 all: theme-install-dep theme-build up
 
 up:
-	docker-compose pull
-	docker-compose up -d
+	docker compose pull
+	docker compose up -d
 
 cli:
-	docker-compose run --rm documentation sh
+	docker compose run --rm documentation sh
 
 logs:
-	docker-compose logs -f
+	docker compose logs -f
 
 check:
-	docker-compose run -T --rm documentation npm run check
+	docker compose run -T --rm documentation npm run check
 
 # Sparkkit based themes specific commands.
 theme-watch:

--- a/bin/npm
+++ b/bin/npm
@@ -9,4 +9,4 @@ if [ -z "$CMD" ]
 then
   CMD="version"
 fi
-docker-compose run -w "/opt/raneto/themes/spark-playbook" --rm documentation npm ${CMD}
+docker compose run -w "/opt/raneto/themes/spark-playbook" --rm documentation npm ${CMD}


### PR DESCRIPTION
I noticed that this project is still using the syntax of Docker Compose V1. I updated the setup for the V2, which is pretty straightforward. The update is especially useful for all the Docker Desktop users, which do not have the old docker-compose installed by default since July 2023 ([read more here](https://docs.docker.com/compose/migrate)).