### PR TITLE
refs #209: Add entrypoint for node modules.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,33 +5,23 @@ LABEL author="Paolo Pustorino <paolo.pustorino@sparkfabrik.com>"
 ENV INSTALL_DIR=/opt/raneto
 ENV PORT=80
 
+# Set current working directory
+WORKDIR $INSTALL_DIR
+
 # Copy content and configuration
-COPY ./custom/server.js $INSTALL_DIR/
-COPY ./custom/package.json $INSTALL_DIR/
-COPY ./custom/package-lock.json $INSTALL_DIR/
-COPY ./custom/config.js $INSTALL_DIR/config.js
-COPY ./custom/themes $INSTALL_DIR/themes
-COPY ./content $INSTALL_DIR/content
-COPY ./assets $INSTALL_DIR/assets
-COPY ./custom/patches $INSTALL_DIR/patches
-
-# Install raneto and deps
-WORKDIR $INSTALL_DIR
-RUN npm ci && npm run postinstall
-
-# Move to the theme folder
-# to build the public/dist folder.
-# Raneto will search for public assets
-# here first.
-WORKDIR $INSTALL_DIR/themes/spark-playbook
-RUN \
-  npm ci && \
-  npm run build
-
-WORKDIR $INSTALL_DIR
+COPY ./custom/server.js ./
+COPY ./custom/package.json ./
+COPY ./custom/package-lock.json ./
+COPY ./custom/config.js ./config.js
+COPY ./custom/themes ./themes
+COPY ./content ./content
+COPY ./assets ./assets
+COPY ./custom/patches ./patches
 
 # Expose port 80
 EXPOSE $PORT
 
-# Let's go
-CMD ["npm", "start"]
+# Configure the entrypoint script
+COPY build/node/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-all: theme-install-dep theme-build up
+all: up
 
 up:
 	docker compose pull

--- a/build/node/entrypoint.sh
+++ b/build/node/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/ash
+
+set -eo pipefail
+BASE=${PWD}
+
+if [ "${1}" = 'npm' ]; then
+echo "Installing and building theme..."
+  cd /opt/raneto/themes/spark-playbook
+  npm install
+  npm run build
+  echo "Finished installing and building theme."
+
+  echo "Installing raneto's npm libraries..."
+  cd /opt/raneto
+  npm install
+  npm run postinstall
+  echo "Finished installing raneto's npm libraries."
+
+  echo "...done\n"
+fi
+
+cd ${BASE}
+echo "Running command: ${@}"
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: .
     environment:
       - VIRTUAL_HOST=playbook.sparkfabrik.loc
+    command: npm run start
     volumes:
       - ./assets:/opt/raneto/assets
       - ./content:/opt/raneto/content


### PR DESCRIPTION
refs #209: From now on, every time the container is instantiated, the entrypoint script will handle the setup for the npm libraries (both theme and raneto). In the makefile the commands `theme-install-dep` and `theme-build up` are still there, but they do not need to be called with `make` or `make up` (they are only needed when developing the theme).

Inside the entrypoint I used `npm install` instead of `npm ci`, which speeds up the process, since it does not reinstall each time all the libraries.