### PR TITLE
build: add port forwarding for accessing local container in windows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "3"
 services:
   documentation:
+    ports:
+      - "127.0.0.1:80:80"
     build:
       context: .
       target: dev


### PR DESCRIPTION
This allows the local container to be accessed via http://localhost on Windows host