### PR TITLE
refs #230: Fix GitLab CI resource page link

### DIFF
--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -14,29 +14,29 @@ Please find here a TOC of the available training resources.
 
 **Core skills training resources**
 
-| Area | Topic |
-|---|---|
-| [Basics](#basics) | [Command line / Shell](#command-line--shell) |
-|        | [Security](#security) |
-|        | [Networking](#networking) |
-| [Tools](#tools) | [YAML](#yaml) |
-|        | [Git](#git) |
-|        | [GitHub Copilot](#github-copilot) (bonus track) |
+| Area              | Topic                                                   |
+|-------------------|---------------------------------------------------------|
+| [Basics](#basics) | [Command line / Shell](#command-line--shell)            |
+|                   | [Security](#security)                                   |
+|                   | [Networking](#networking)                               |
+| [Tools](#tools)   | [YAML](#yaml)                                           |
+|                   | [Git](#git)                                             |
+|                   | [GitHub Copilot](#github-copilot) (bonus track)         |
 | [DevOps](#devops) | [Docker and Docker Compose](#docker-and-docker-compose) |
-|        | [Kubernetes](#kubernetes) |
-|        | [CI/CD](#cicd) (on GitLab and GitHub) |
+|                   | [Kubernetes](#kubernetes)                               |
+|                   | [CI/CD](#cicd) (on GitLab and GitHub)                   |
 
 **Other training resources**
 
-| Name | Area | Topics | Access type |
-|---|---|---|---|
-| [Udemy](#udemy) | Development | Angular, React, React Native, Hasura | Credentials |
-| [Ultimate Courses](#ultimate-courses) | Development | Angular, React, Typescript | Credentials |
-| [Drupalize.me](#drupalizeme) | Development | Drupal | Credentials |
-| [Frontend Masters](#frontend-masters) | Development | Angular, React, Python, Go, Rust, UX design, management | Credentials |
-| [AWS Skill Builder](#aws-skill-builder) | Cloud | Amazon Web Services | Corporate account |
-| [Google SkillBoost](#google-skillboost) | Cloud | Google Cloud Platform | Corporate account |
-| [Cloud Academy](#cloud-academy) | Cloud | Vendor-specific services (AWS, GCP, Azure, Alibaba), Kubernetes, complete Cloud training offering | Reserved seats |
+| Name                                    | Area        | Topics                                                                                            | Access type       |
+|-----------------------------------------|-------------|---------------------------------------------------------------------------------------------------|-------------------|
+| [Udemy](#udemy)                         | Development | Angular, React, React Native, Hasura                                                              | Credentials       |
+| [Ultimate Courses](#ultimate-courses)   | Development | Angular, React, Typescript                                                                        | Credentials       |
+| [Drupalize.me](#drupalizeme)            | Development | Drupal                                                                                            | Credentials       |
+| [Frontend Masters](#frontend-masters)   | Development | Angular, React, Python, Go, Rust, UX design, management                                           | Credentials       |
+| [AWS Skill Builder](#aws-skill-builder) | Cloud       | Amazon Web Services                                                                               | Corporate account |
+| [Google SkillBoost](#google-skillboost) | Cloud       | Google Cloud Platform                                                                             | Corporate account |
+| [Cloud Academy](#cloud-academy)         | Cloud       | Vendor-specific services (AWS, GCP, Azure, Alibaba), Kubernetes, complete Cloud training offering | Reserved seats    |
 
 ## Core Skills training resources
 
@@ -54,33 +54,33 @@ All the training material in this section is public and can be freely accessed.
 
 > **Time to completion**: 24 hours.
 
-| Resources | |
-|---|---|
-| **Documentation** | [Makefile Tutorial](https://makefiletutorial.com/) |
-| **Hands-on** | [The Shell (LinuxJourney)](https://linuxjourney.com/lesson/the-shell) |
-| | [Output redirection (LinuxJourney)](https://linuxjourney.com/lesson/stdout-standard-out-redirect) |
-| | [Bash Crawl (SlackerMedia)](https://gitlab.com/slackermedia/bashcrawl#try-it-online-with-mybinder) |
+| Resources         |                                                                                                    |
+|-------------------|----------------------------------------------------------------------------------------------------|
+| **Documentation** | [Makefile Tutorial](https://makefiletutorial.com/)                                                 |
+| **Hands-on**      | [The Shell (LinuxJourney)](https://linuxjourney.com/lesson/the-shell)                              |
+|                   | [Output redirection (LinuxJourney)](https://linuxjourney.com/lesson/stdout-standard-out-redirect)  |
+|                   | [Bash Crawl (SlackerMedia)](https://gitlab.com/slackermedia/bashcrawl#try-it-online-with-mybinder) |
 
 ### Security
 
 > **Time to completion**: 4 hours for the documentation; hands-on are considered a long-term goal, check the note.
 
-| Resources | |
-|---|---|
-| **Documentation** | [Concise Guide for Developing More Secure Software (OpenSSF)](https://best.openssf.org/Concise-Guide-for-Developing-More-Secure-Software.html) |
-| | [Concise Guide for Evaluating Open Source Software (OpenSSF)](https://best.openssf.org/Concise-Guide-for-Evaluating-Open-Source-Software.html) |
-| | [Source Code Management Best Practices Guide (OpenSSF)](https://best.openssf.org/SCM-BestPractices/) |
-| | [The Secure Software Factory (CNCF Tag Security Whitepaper)](https://github.com/cncf/tag-security/blob/main/supply-chain-security/secure-software-factory/Secure_Software_Factory_Whitepaper.pdf) |
-| **Hands-on** | [Developing Secure Software (LFD121)](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/) <sup><a href="#fn1">1</a></sup> |
+| Resources         |                                                                                                                                                                                                   |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Documentation** | [Concise Guide for Developing More Secure Software (OpenSSF)](https://best.openssf.org/Concise-Guide-for-Developing-More-Secure-Software.html)                                                    |
+|                   | [Concise Guide for Evaluating Open Source Software (OpenSSF)](https://best.openssf.org/Concise-Guide-for-Evaluating-Open-Source-Software.html)                                                    |
+|                   | [Source Code Management Best Practices Guide (OpenSSF)](https://best.openssf.org/SCM-BestPractices/)                                                                                              |
+|                   | [The Secure Software Factory (CNCF Tag Security Whitepaper)](https://github.com/cncf/tag-security/blob/main/supply-chain-security/secure-software-factory/Secure_Software_Factory_Whitepaper.pdf) |
+| **Hands-on**      | [Developing Secure Software (LFD121)](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/) <sup><a href="#fn1">1</a></sup>                                           |
 
 ### Networking
 
 > **Time to completion**: 1 hour.
 
-| Resources | |
-|---|---|
+| Resources         |                                            |
+|-------------------|--------------------------------------------|
 | **Documentation** | [How DNS works](https://howdns.works/ep1/) |
-| | [How HTTPS works](https://howhttps.works/) |
+|                   | [How HTTPS works](https://howhttps.works/) |
 
 ## Tools
 
@@ -96,25 +96,25 @@ All the training material in this section is public and can be freely accessed.
 
 > **Time to completion**: 12 hours for the documentation; 18 hours for the hands-on.
 
-| Resources | |
-|---|---|
-| **Documentation** | [Git Tutorial (NuLab)](https://nulab.com/learn/software-development/git-tutorial/) |
-| | [Understanding Git Conceptually](https://www.cduan.com/technical/git/) |
-| | [SparkFabrik Git Workflow](https://playbook.sparkfabrik.com/procedures/git-workflow) |
-| | [GitLab Flow](https://docs.gitlab.com/ee/topics/gitlab_flow.html) |
-| | [Semantic Versioning](https://semver.org/) |
-| **Hands-on** | [Learning Git Branching](https://learngitbranching.js.org/) |
-| | [Oh my Git](https://ohmygit.org/) |
-| | [Visualizing Git](https://git-school.github.io/visualizing-git/) |
+| Resources         |                                                                                      |
+|-------------------|--------------------------------------------------------------------------------------|
+| **Documentation** | [Git Tutorial (NuLab)](https://nulab.com/learn/software-development/git-tutorial/)   |
+|                   | [Understanding Git Conceptually](https://www.cduan.com/technical/git/)               |
+|                   | [SparkFabrik Git Workflow](https://playbook.sparkfabrik.com/procedures/git-workflow) |
+|                   | [GitLab Flow](https://docs.gitlab.com/ee/topics/gitlab_flow.html)                    |
+|                   | [Semantic Versioning](https://semver.org/)                                           |
+| **Hands-on**      | [Learning Git Branching](https://learngitbranching.js.org/)                          |
+|                   | [Oh my Git](https://ohmygit.org/)                                                    |
+|                   | [Visualizing Git](https://git-school.github.io/visualizing-git/)                     |
 
 ### GitHub Copilot
 
 > **Time to completion**: 1 hours for the documentation and installation.
 
-| Resources | |
-|---|---|
+| Resources         |                                                                                |
+|-------------------|--------------------------------------------------------------------------------|
 | **Documentation** | [Quickstart for GitHub Copilot](https://docs.github.com/en/copilot/quickstart) |
-| | [SparkFabrik's policy on Copilot](/tools-and-policies/github-copilot) |
+|                   | [SparkFabrik's policy on Copilot](/tools-and-policies/github-copilot)          |
 
 ## DevOps
 
@@ -122,32 +122,32 @@ All the training material in this section is public and can be freely accessed.
 
 > **Time to completion**: 3 hours for the documentation; 3 hours for the hands-on.
 
-| Resources | |
-|---|---|
-| **Documentation** | [Docker - Zero to Hero (TechWorld with Nana - YouTube)](https://youtu.be/3c-iBn73dDE) |
-| | [Docker-Compose Tutorial (TechWorld with Nana - YouTube)](https://youtu.be/MVIcrmeV_6c) |
-| **Hands-on** | [Docker 101 Tutorial](https://www.docker.com/101-tutorial/) |
+| Resources         |                                                                                         |
+|-------------------|-----------------------------------------------------------------------------------------|
+| **Documentation** | [Docker - Zero to Hero (TechWorld with Nana - YouTube)](https://youtu.be/3c-iBn73dDE)   |
+|                   | [Docker-Compose Tutorial (TechWorld with Nana - YouTube)](https://youtu.be/MVIcrmeV_6c) |
+| **Hands-on**      | [Docker 101 Tutorial](https://www.docker.com/101-tutorial/)                             |
 
 ### Kubernetes
 
 > **Time to completion**: 1 hour for the documentation; 12 hours for the hands-on.
 
-| Resources | |
-|---|---|
+| Resources         |                                                                                                                                                                           |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Documentation** | [The Illustrated Childrens Guide to Kubernetes (Italian)](https://www.cncf.io/wp-content/uploads/2021/11/The-Illustrated-Childrens-Guide-to-Kubernetes-Italian-Spark.pdf) |
-| **Hands-on** | [Kubernetes (KillerCoda)](https://killercoda.com/kubernetes) <sup><a href="#fn2">2</a></sup> |
+| **Hands-on**      | [Kubernetes (KillerCoda)](https://killercoda.com/kubernetes) <sup><a href="#fn2">2</a></sup>                                                                              |
 
 ### CI/CD
 
 > **Time to completion**: 4 hour for the documentation; 4 hours for the hands-on.
 
-| Resources | |
-|---|---|
-| **Documentation** | [Introduction to CI (GitLab Documentation)](https://docs.gitlab.com/ee/ci/introduction/) |
-| | [Create and run your first GitLab CI/CD pipeline (GitLab Tutorial)](https://docs.gitlab.com/ee/ci/quick_start/) |
-| | [GitLab CI/CD in one hour (TechWorld with Nana - YouTube)](https://youtu.be/qP8kir2GUgo) |
-| | [Understanding GitHub Actions (GitHub Docs)](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) |
-| **Hands-on** | [Become a GitHub Actions Hero](https://github-actions-hero.vercel.app/) |
+| Resources         |                                                                                                                                    |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| **Documentation** | [Introduction to CI (GitLab Documentation)](https://docs.gitlab.com/ee/ci/)                                                        |
+|                   | [Create and run your first GitLab CI/CD pipeline (GitLab Tutorial)](https://docs.gitlab.com/ee/ci/quick_start/)                    |
+|                   | [GitLab CI/CD in one hour (TechWorld with Nana - YouTube)](https://youtu.be/qP8kir2GUgo)                                           |
+|                   | [Understanding GitHub Actions (GitHub Docs)](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) |
+| **Hands-on**      | [Become a GitHub Actions Hero](https://github-actions-hero.vercel.app/)                                                            |
 
 ## Other training resources
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Fixed broken GitLab CI documentation link to point to the correct resource page
- Enhanced readability of markdown tables by:
  - Standardizing column spacing and alignment
  - Improving visual structure of training resources tables
  - Maintaining consistent formatting across all sections



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>training-resources.md</strong><dd><code>Fix GitLab CI link and improve table formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

content/resources/training-resources.md

<li>Fixed GitLab CI documentation link from <br>'docs.gitlab.com/ee/ci/introduction/' to 'docs.gitlab.com/ee/ci/'<br> <li> Improved table formatting and alignment across the document<br> <li> Updated table structure with consistent column spacing<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/company-playbook/pull/231/files#diff-6aa9650cf85beaf399cc7dba7d1fbf30c732f1b853731488814834455a38a360">+63/-63</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information