### PR TITLE
platform/#2231: use artifact registry instead of GCR and update actions

### DIFF
--- a/.github/workflows/cloud-run.yml
+++ b/.github/workflows/cloud-run.yml
@@ -21,6 +21,8 @@ on:
 
 env:
   PROJECT_ID: ${{ secrets.RUN_PROJECT }}
+  IMAGE_REGISTRY: europe-west1-docker.pkg.dev
+  IMAGE_REPOSITORY: ${{ secrets.RUN_PROJECT }}/sparkfabrik-applications
   RUN_REGION: europe-west1
   SERVICE_NAME: company-playbook
   SERVICE_ACCOUNT: ${{ secrets.CLOUD_RUN_SERVICE_ACCOUNT }}
@@ -32,16 +34,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: google-github-actions/auth@v1
+      - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.RUN_SA_CREDS }}
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: google-github-actions/setup-gcloud@v2
         with:
-          version: "411.0.0"
           #service_account_key: ${{ secrets.RUN_SA_KEY }}
           project_id: ${{ secrets.RUN_PROJECT }}
 
@@ -50,22 +51,22 @@ jobs:
         run: |-
           gcloud builds submit \
             --quiet \
-            --tag "eu.gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA"
+            --tag "${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${SERVICE_NAME}:${GITHUB_SHA}"
 
       # Deploy image to Cloud Run
       - name: Deploy
         run: |-
-          gcloud run deploy "$SERVICE_NAME" \
+          gcloud run deploy "${SERVICE_NAME}" \
             --quiet \
-            --region "$RUN_REGION" \
-            --image "eu.gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA" \
+            --region "${RUN_REGION}" \
+            --image "${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${SERVICE_NAME}:${GITHUB_SHA}" \
             --platform "managed" \
-            --service-account="$SERVICE_ACCOUNT" \
+            --service-account="${SERVICE_ACCOUNT}" \
             --allow-unauthenticated
 
       # Update traffic routing to send all traffic to the latest revision
       - name: Update traffic
         run: |-
-          gcloud run services update-traffic "$SERVICE_NAME" \
-            --region "$RUN_REGION" \
+          gcloud run services update-traffic "${SERVICE_NAME}" \
+            --region "${RUN_REGION}" \
             --to-latest


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Switched container image storage from Google Container Registry (GCR) to Artifact Registry (europe-west1-docker.pkg.dev)
- Updated GitHub Actions dependencies to latest versions:
  - actions/checkout from v3 to v4
  - google-github-actions/auth from v1 to v2
  - google-github-actions/setup-gcloud from v1 to v2
- Removed hardcoded gcloud CLI version requirement
- Added explicit environment variables for image registry configuration
- Improved shell variable interpolation syntax in gcloud commands



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloud-run.yml</strong><dd><code>Migrate to Artifact Registry and update GitHub Actions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/cloud-run.yml

<li>Migrated from Google Container Registry (GCR) to Artifact Registry for <br>container images<br> <li> Updated GitHub Actions dependencies to newer versions (checkout@v4, <br>auth@v2, setup-gcloud@v2)<br> <li> Added new environment variables for image registry configuration<br> <li> Improved variable interpolation syntax using ${} format


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/company-playbook/pull/238/files#diff-be48d5ca14b22b725d260b8265f2139e60a2ca4c124f40fa1b66a088a392f2a6">+12/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information