### PR TITLE
fix: copilot settings page url

### DIFF
--- a/content/tools-and-policies/github-copilot.md
+++ b/content/tools-and-policies/github-copilot.md
@@ -46,7 +46,7 @@ Purpose: This policy aims to establish guidelines for using GitHub Copilot withi
 ## How to request a subscription
 
 You should have been granted a GitHub Copilot subscription during your onboarding. If that's not the case, you can apply by doing as follows:
-- on the [Github Copilot page](https://github.com/features/copilot), locate the section **Get Copilot from an organization**
+- on the [Github Copilot settings page](https://github.com/settings/copilot) of your profile, locate the section **Get Copilot from an organization**
 - use the action **Ask admin for access** on the **SparkFabrik** organization
 - ask an HR representative for a confirmation using the channel `#support-hr`
 


### PR DESCRIPTION
### **User description**
fix #240


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect GitHub Copilot URL in documentation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github-copilot.md</strong><dd><code>Update GitHub Copilot URL to correct settings page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

content/tools-and-policies/github-copilot.md

<li>Updated the URL for GitHub Copilot from features/copilot to <br>settings/copilot<br> <li> Changed link text from "Github Copilot page" to "Github Copilot <br>settings page"


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/company-playbook/pull/241/files#diff-22956c804e1467805d3cc85f7f2ac6a551838b5114abf5fca02bba42f505504d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>