### PR TITLE
refs #274: add policy on mr and pr agent.

### DIFF
--- a/content/tools-and-policies/gitlab-mr-policy.md
+++ b/content/tools-and-policies/gitlab-mr-policy.md
@@ -1,0 +1,15 @@
+# Merge Requests Policy
+
+When a team member works on a task, they may create a merge request and set it to _Draft_. The merge request should be linked to the corresponding card on the project board by including the card's reference (refs) in the title.
+
+When the work on the issue is complete, the author MUST run the PR Agent (using `/improve`) and review its suggestions. The PR Agent is a mandatory, automated step and MUST be executed before requesting a human review.
+
+The bot will propose code improvements; the author must address each suggestion either by applying it or by leaving a comment explaining why it is not applicable. The author must keep the merge request updated and use the `/improve` and `/review` commands to indicate the current status to reviewers. Addressing PR Agent suggestions and ensuring the MR is up-to-date with `/improve` and `/review` are prerequisites for requesting a human review.
+
+After these prerequisites are met, the author may assign the merge request to another developer for human review. The reviewer checks the code for correctness, completeness, and adherence to coding standards, leaving comments if necessary. The author must address reviewer comments before the review is approved.
+
+Once the reviewer is satisfied, they approve the merge request. The author then updates the merge request description, using the `/describe` PR Agent command as a starting point.
+
+Note on `/describe` (optional but useful): `/describe` can be invoked multiple times to refresh the MR description. It preserves any manual description previously written by humans, so it's safe to run again later in the review lifecycle (for example to summarise fixes introduced during review).
+
+To re-run the automated steps, comment with `/improve` or `/review` in the MR discussion as separate comments; this will retrigger the corresponding action for reviewers or the PR Agent.


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Add comprehensive merge request policy documentation

- Define mandatory PR Agent usage requirements

- Establish review workflow with automated steps

- Specify prerequisites for human review requests


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab-mr-policy.md</strong><dd><code>New GitLab merge request policy documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

content/tools-and-policies/gitlab-mr-policy.md

<li>Create new merge request policy document<br> <li> Define mandatory PR Agent usage with <code>/improve</code> command<br> <li> Establish workflow from draft to human review<br> <li> Specify requirements for addressing bot suggestions


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/company-playbook/pull/275/files#diff-4e4521138b40bb8b147e39574300937aa88482ca63ed7893f8164d0f74d1dee3">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>