### PR TITLE
docs: address AI section feedback from review

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as dev
+FROM node:22-alpine as dev
 LABEL author="Paolo Pustorino <paolo.pustorino@sparkfabrik.com>"
 
 RUN apk add --no-cache tini

--- a/content/ai-development/openspec-reference.md
+++ b/content/ai-development/openspec-reference.md
@@ -13,6 +13,7 @@ Sort: 45
 | Validate before archive | `openspec validate <name>` |
 | Specs source of truth | `openspec/specs/` |
 | Active changes | `openspec/changes/` |
+| New to OpenSpec? | Start with `/opsx:onboard` in a chat session |
 
 ## Table of Contents
 

--- a/content/ai-development/openspec-reference.md
+++ b/content/ai-development/openspec-reference.md
@@ -3,8 +3,20 @@ Description: OpenSpec framework reference: concepts, commands, and project file 
 Sort: 45
 */
 
+## TL;DR
+
+| What you need | Where to look |
+|---------------|---------------|
+| Workflow commands | `/opsx:explore`, `/opsx:ff`, `/opsx:apply`, `/opsx:archive` |
+| Step-by-step alternative | `/opsx:new` + `/opsx:continue` |
+| Check progress | `openspec status --change <name>` |
+| Validate before archive | `openspec validate <name>` |
+| Specs source of truth | `openspec/specs/` |
+| Active changes | `openspec/changes/` |
+
 ## Table of Contents
 
+- [TL;DR](#tldr)
 - [Overview](#overview)
 - [The core flow](#the-core-flow)
 - [Key concepts](#key-concepts)

--- a/content/ai-development/openspec-reference.md
+++ b/content/ai-development/openspec-reference.md
@@ -1,0 +1,230 @@
+/*
+Description: OpenSpec framework reference: concepts, commands, and project file structure
+Sort: 45
+*/
+
+## Table of Contents
+
+- [Overview](#overview)
+- [The core flow](#the-core-flow)
+- [Key concepts](#key-concepts)
+- [Commands](#commands)
+- [Project files reference](#project-files-reference)
+
+## Overview
+
+[OpenSpec](https://github.com/Fission-AI/OpenSpec) is an open-source, tool-agnostic framework for Spec-Driven Development. It supports [multiple AI coding assistants](https://github.com/Fission-AI/OpenSpec#supported-tools): we use it with GitHub Copilot and OpenCode, but it also works with Cursor, Windsurf, Claude Code, and others.
+
+For the methodology behind OpenSpec — why we use specs, how they fit into our workflow, and a complete walkthrough of a feature implementation — see **[Spec-Driven Development](/ai-development/spec-driven-development)**.
+
+## The core flow
+
+```
+  explore ──────► create ──────► apply ──────► archive
+     │               │              │              │
+   understand      proposal       implement      merge specs
+   the problem     specs          the tasks      into source
+                   design                        of truth
+                   tasks
+```
+
+1. **Explore**: Understand the problem. Investigate the codebase, compare approaches, surface trade-offs. No code or artifacts are created yet.
+2. **Create**: Define the change. OpenSpec generates a proposal, delta specs, design, and task list. Use `/opsx:ff` to create everything at once, or `/opsx:new` + `/opsx:continue` for step-by-step control.
+3. **Apply**: Work through the implementation tasks, checking them off as you go.
+4. **Archive**: When complete, delta specs merge into the main spec library and the change moves to the archive for audit history.
+
+The flow is a recommendation, not a mandate. You can skip straight to `/opsx:ff` if you already understand the problem, or run `/opsx:explore` multiple times before creating anything. The only hard dependency is that you create a change before applying it, and apply before archiving.
+
+## Key concepts
+
+**Specs** (`openspec/specs/`) are the source of truth: they describe how the system currently behaves, organized by domain. You can inspect them with the CLI:
+
+```
+$ openspec list --specs
+Specs:
+  auth-session     requirements 2
+```
+
+A spec contains structured requirements with concrete scenarios:
+
+```markdown
+# Auth Session Specification
+
+## Purpose
+Manage user session lifecycle including creation, validation, and authentication state.
+
+## Requirements
+
+### Requirement: Session Creation
+The system SHALL create a session token upon successful authentication.
+
+#### Scenario: Successful login
+- GIVEN a user with valid credentials
+- WHEN the user submits the login form
+- THEN a session token is issued
+- AND the user is redirected to the dashboard
+```
+
+**Changes** (`openspec/changes/`) are proposed modifications. Each change is a self-contained folder with everything needed to understand and implement it:
+
+```
+openspec/changes/add-session-timeout/
+├── proposal.md           # Why and what (intent, scope, approach)
+├── design.md             # How (technical decisions, architecture)
+├── tasks.md              # Implementation checklist
+└── specs/                # Delta specs
+    └── auth-session/
+        └── spec.md       # What's changing in the auth-session spec
+```
+
+You can check the status of a change with the CLI:
+
+```
+$ openspec status --change add-session-timeout
+Change: add-session-timeout
+Schema: spec-driven
+Progress: 4/4 artifacts complete
+
+[x] proposal
+[x] design
+[x] specs
+[x] tasks
+
+All artifacts complete!
+```
+
+**Delta specs** describe what's changing relative to the current specs, using `ADDED`, `MODIFIED`, and `REMOVED` sections. This is what makes OpenSpec work well for brownfield development: you specify the change, not the entire system:
+
+```markdown
+# Delta for Auth Session
+
+## ADDED Requirements
+
+### Requirement: Session Expiration
+The system SHALL expire sessions after a configured duration of inactivity.
+
+#### Scenario: Idle timeout
+- GIVEN an authenticated user session
+- WHEN 30 minutes pass without activity
+- THEN the session token is invalidated
+- AND the user is redirected to the login page
+```
+
+**Artifacts** are the documents within a change (proposal, specs, design, tasks). They build on each other but can be updated at any time as understanding deepens.
+
+When a change is archived, its delta specs merge into the main specs. You can validate a change before archiving:
+
+```
+$ openspec validate add-session-timeout
+Change 'add-session-timeout' is valid
+```
+
+And when you archive, the delta is applied to the source of truth:
+
+```
+$ openspec archive add-session-timeout --yes
+Specs to update:
+  auth-session: update
+Applying changes to openspec/specs/auth-session/spec.md:
+  + 2 added
+Totals: + 2, ~ 0, - 0, → 0
+Specs updated successfully.
+Change 'add-session-timeout' archived as '2026-03-09-add-session-timeout'.
+```
+
+The spec now describes the new behavior (4 requirements instead of 2), and the next change builds on the updated source of truth.
+
+**Who maintains the specs?** The team that owns the domain owns its specs. Specs stay current naturally through the archive flow, since every change that touches a domain updates the relevant spec as part of its merge. If you notice a spec has drifted from reality (e.g., after a refactor that didn't use OpenSpec), update it directly or create a small change to realign it.
+
+## Commands
+
+Both GitHub Copilot and OpenCode use the same slash commands. Type them in the chat interface of either tool. Each command maps to a prompt file in your repository (under `.opencode/command/` or `.github/prompts/`) that instructs the AI what to do. You can read or customize them like any other file.
+
+**Workflow commands**, the full cycle from idea to archived specs:
+
+| Command | What it does |
+|---------|-------------|
+| `/opsx:explore` | Think through ideas, investigate the codebase, compare approaches; no code written |
+| `/opsx:ff <name>` | Create a change with all artifacts at once (proposal, specs, design, tasks) |
+| `/opsx:apply` | Implement tasks from the current change |
+| `/opsx:archive` | Archive a completed change, merging delta specs into the source of truth |
+
+**Step-by-step alternative**: use `/opsx:new` + `/opsx:continue` instead of `/opsx:ff` when you want to review and refine each artifact before moving to the next:
+
+| Command | What it does |
+|---------|-------------|
+| `/opsx:new <name>` | Scaffold a change directory and show the first artifact template |
+| `/opsx:continue` | Create the next artifact (one at a time) |
+
+**Additional commands:**
+
+| Command | What it does |
+|---------|-------------|
+| `/opsx:verify` | Check that implementation matches the specs before archiving |
+| `/opsx:sync` | Sync delta specs to main specs without archiving |
+| `/opsx:bulk-archive` | Archive multiple completed changes at once |
+| `/opsx:onboard` | Guided walkthrough of the full OpenSpec workflow; start here if you're new |
+
+**CLI commands**: the `openspec` CLI complements the slash commands with direct operations you run in your terminal:
+
+| Command | What it does |
+|---------|-------------|
+| `openspec list` | List active changes |
+| `openspec list --specs` | List specs in the source of truth |
+| `openspec status --change <name>` | Show artifact progress for a change |
+| `openspec validate <name>` | Check that a change is valid before archiving |
+| `openspec show <name>` | Display change details and artifacts |
+| `openspec archive <name>` | Archive a change, merging delta specs into the source of truth |
+| `openspec schemas` | List available workflow schemas. A schema defines which artifacts a change contains (e.g. `spec-driven` includes proposal, specs, design, tasks) |
+
+These are especially useful in CI pipelines (e.g. `openspec validate` as a pre-merge check) and for quick inspections without opening an AI chat session.
+
+Between creating and applying, review and refine the artifacts. They're just Markdown files. Edit them directly if needed. You can also run `openspec status --change <name>` at any point to check progress.
+
+## Project files reference
+
+`openspec init --tools opencode,github-copilot` creates the following files. **Commit all of them**; there is nothing to `.gitignore`.
+
+```
+your-project/
+│
+├── openspec/                          # Spec-driven development root
+│   ├── specs/                         # Source of truth (empty at init, grows as you archive)
+│   └── changes/                       # Active changes live here
+│
+├── .opencode/                         # OpenCode integration
+│   ├── command/                       # Slash commands
+│   │   ├── opsx-apply.md
+│   │   ├── opsx-archive.md
+│   │   ├── opsx-explore.md
+│   │   ├── opsx-new.md
+│   │   ├── opsx-ff.md
+│   │   ├── opsx-continue.md
+│   │   ├── opsx-verify.md
+│   │   ├── opsx-sync.md
+│   │   ├── opsx-bulk-archive.md
+│   │   └── opsx-onboard.md
+│   └── skills/                        # Skills (one folder each)
+│       ├── openspec-apply-change/
+│       ├── openspec-archive-change/
+│       ├── openspec-explore/
+│       ├── openspec-new-change/
+│       ├── openspec-ff-change/
+│       ├── openspec-continue-change/
+│       ├── openspec-verify-change/
+│       ├── openspec-sync-specs/
+│       ├── openspec-bulk-archive-change/
+│       └── openspec-onboard/
+│
+└── .github/                           # GitHub Copilot integration
+    ├── prompts/                       # Slash commands (same names, .prompt.md extension)
+    │   ├── opsx-apply.prompt.md
+    │   ├── opsx-archive.prompt.md
+    │   └── ...                        # (same set as .opencode/command/)
+    └── skills/                        # Skills (same structure as .opencode/skills/)
+        ├── openspec-apply-change/
+        ├── openspec-archive-change/
+        └── ...
+```
+
+If you use a different AI tool (Cursor, Windsurf, Claude Code), run `openspec init --tools <tool-name>` instead; see the [supported tools list](https://github.com/Fission-AI/OpenSpec#supported-tools). You can initialize multiple tools at once.

--- a/content/ai-development/overview.md
+++ b/content/ai-development/overview.md
@@ -9,6 +9,7 @@ Sort: 10
   - [IDE](#ide)
   - [CLI tools](#cli-tools)
 - [How the pieces fit together](#how-the-pieces-fit-together)
+- [Beyond development](#beyond-development)
 - [Principles](#principles)
 - [Getting started](#getting-started)
 
@@ -50,6 +51,14 @@ The tools above are general-purpose out of the box. We extend them in two ways:
 **Skills and agent profiles** customize how the coding agents behave, adding domain knowledge, safety protocols, and role-specific configurations. SparkFabrik maintains a shared catalog in [sf-awesome-copilot](https://github.com/sparkfabrik/sf-awesome-copilot), synced to your machine automatically by sparkdock. You can also create your own, and each project can define its own alongside the code. See [Skills and Agents](/ai-development/skills-and-agents) for how they work and where they live.
 
 **Spec-Driven Development** adds structure to how we use AI on non-trivial work. Instead of jumping straight to code, we capture intent and requirements as artifacts that the AI can reference and reviewers can verify against. See [Spec-Driven Development](/ai-development/spec-driven-development) for the methodology.
+
+## Beyond development
+
+The pages in this section focus on **development workflows**: coding agents, terminal tools, and spec-driven methodologies. If you're a developer or cloud engineer, this is your starting point.
+
+For **non-development roles** — project managers, analysts, marketing, administrative roles, and similar — **[Claude.ai](https://claude.ai)** is the AI tool we've adopted for work. It's well suited for writing, research, analysis, brainstorming, and structured thinking. Claude is provided through a company subscription; if you don't have access yet, ask your manager or reach out on `#support-hr`. Dedicated guidance for using Claude in these roles is coming.
+
+For **UI/UX designers**, we are evaluating specialized tools — specifically [Google Stitch](https://stitch.withgoogle.com) and Figma AI/Make — but we haven't converged on an approach yet. If you're a designer using AI in your workflow, we'd love to hear what's working for you; your input will shape what we recommend here.
 
 ## Principles
 

--- a/content/ai-development/security.md
+++ b/content/ai-development/security.md
@@ -3,8 +3,17 @@ Description: Security practices for AI-assisted development: prompt hygiene, con
 Sort: 25
 */
 
+## TL;DR
+
+- **Never put credentials, PII, or client secrets in prompts** — treat prompts like emails
+- **Copilot content exclusion does NOT work for CLI agents** — human review is the primary safeguard
+- **Both tools are configured with safe defaults at the org level**: GitHub Copilot has content exclusion for `.env` and sensitive paths (IDE only); OpenCode blocks `.env` files and [sparkdock](https://github.com/sparkfabrik/sparkdock/blob/master/config/macos/opencode.json) adds 150+ permission rules for destructive commands
+- **Your data is not used for training** on commercial plans (Copilot, Claude for Work)
+- **If a secret is committed**: revoke first, clean history second, notify the team
+
 ## Table of Contents
 
+- [TL;DR](#tldr)
 - [Prompt hygiene](#prompt-hygiene)
 - [Content exclusion](#content-exclusion)
 - [Agent permissions](#agent-permissions)
@@ -44,7 +53,7 @@ For agentic tools, the safeguards are:
 - **sparkdock configures safe defaults.** Destructive operations (force-push, file deletion outside the project, etc.) require confirmation. See [Agent permissions](#agent-permissions) below.
 - **`.gitignore` is your last line of defense.** Ensure secrets, key files, and environment configs are gitignored. If a file isn't tracked, an agent can still read it, but it won't end up in a commit unless you explicitly add it.
 
-Content exclusion is still worth configuring for IDE usage. To set it up for a repository, go to the repository's **Settings > Copilot > Content exclusion** on GitHub and add the paths you want to exclude. For organization-wide rules, an admin can configure them in the organization's Copilot settings.
+Content exclusion is already configured at the SparkFabrik organization level for GitHub Copilot, covering `.env` files and other sensitive paths in IDE completions and chat. For additional repository-specific rules, go to the repository's **Settings > Copilot > Content exclusion** on GitHub.
 
 ## Agent permissions
 

--- a/content/ai-development/security.md
+++ b/content/ai-development/security.md
@@ -1,0 +1,124 @@
+/*
+Description: Security practices for AI-assisted development: prompt hygiene, content exclusion, data handling, and incident response
+Sort: 25
+*/
+
+## Table of Contents
+
+- [Prompt hygiene](#prompt-hygiene)
+- [Content exclusion](#content-exclusion)
+- [Agent permissions](#agent-permissions)
+- [Data handling by provider](#data-handling-by-provider)
+- [If something goes wrong](#if-something-goes-wrong)
+- [References](#references)
+
+## Prompt hygiene
+
+Everything you type into an AI tool — prompt, pasted code, file content — is transmitted to a model provider. Treat prompts the way you treat emails: assume they can be read by someone outside the company.
+
+**Never include in a prompt:**
+
+- Credentials, API keys, tokens, or passwords
+- Personally identifiable information (names, emails, phone numbers, addresses)
+- Client-confidential business logic, proprietary algorithms, or trade secrets
+- Database connection strings or infrastructure secrets
+
+**Instead:**
+
+- Reference files by path (`review the auth logic in src/auth/session.ts`) rather than pasting their contents, when the tool has access to your filesystem
+- Use placeholder values when describing patterns (`the API key is stored in FOO_API_KEY`)
+- If you need to share a code snippet, strip secrets first
+
+This applies to all tools: GitHub Copilot (IDE and CLI), OpenCode, and Claude.ai.
+
+## Content exclusion
+
+GitHub Copilot supports [content exclusion](https://docs.github.com/en/copilot/how-tos/configure-content-exclusion/exclude-content-from-copilot) at the repository and organization level. You can configure paths that Copilot should ignore — for example, `secrets.json`, `*.env`, or entire directories containing sensitive data. This is configured in the repository settings on GitHub or in the organization's Copilot settings.
+
+However, there is a critical limitation: **content exclusion does not apply to GitHub Copilot CLI, the Copilot coding agent, or Agent mode in IDE chat**. It only works for inline completions and regular chat in the IDE. Since our primary coding workflows use CLI agents (Copilot CLI and OpenCode), content exclusion alone is not sufficient to protect sensitive files.
+
+For agentic tools, the safeguards are:
+
+- **Human review is the primary gate.** Always review agent-generated changes before committing. This is not optional; it's the most effective protection we have.
+- **OpenCode denies `.env` files by default.** OpenCode's [permission system](https://opencode.ai/docs/permissions) blocks reading `.env` and `.env.*` files out of the box. Access to directories outside the project also requires explicit approval.
+- **sparkdock configures safe defaults.** Destructive operations (force-push, file deletion outside the project, etc.) require confirmation. See [Agent permissions](#agent-permissions) below.
+- **`.gitignore` is your last line of defense.** Ensure secrets, key files, and environment configs are gitignored. If a file isn't tracked, an agent can still read it, but it won't end up in a commit unless you explicitly add it.
+
+Content exclusion is still worth configuring for IDE usage. To set it up for a repository, go to the repository's **Settings > Copilot > Content exclusion** on GitHub and add the paths you want to exclude. For organization-wide rules, an admin can configure them in the organization's Copilot settings.
+
+## Agent permissions
+
+OpenCode provides a granular [permission system](https://opencode.ai/docs/permissions) that controls what the agent can do without asking. Each action (read, edit, bash, etc.) can be set to `allow`, `ask`, or `deny`, with pattern matching for fine-grained control.
+
+Key defaults that [sparkdock configures](https://github.com/sparkfabrik/sparkdock/blob/master/config/macos/opencode.json):
+
+- `.env` and `.env.*` files: **denied** from reading
+- External directories (outside the project): require **approval**
+- Doom loop detection: if the agent repeats the same tool call three times with identical input, it pauses and asks
+- Destructive shell commands: comprehensive rules covering `rm -rf`, `sudo`, `git push --force`, `docker system prune`, `terraform destroy`, `kubectl delete`, cloud provider destructive operations (AWS, GCP, Azure), and more — each classified as either `ask` (requires confirmation) or `deny` (blocked entirely)
+
+You can customize permissions per project (in `opencode.json`) or per agent profile (in the agent's Markdown file). For example, a read-only review agent can deny all edits:
+
+```yaml
+# In an agent profile
+permission:
+  edit: deny
+  bash: ask
+  webfetch: deny
+```
+
+For full documentation on permission patterns, wildcards, and agent-level overrides, see the [OpenCode Permissions docs](https://opencode.ai/docs/permissions).
+
+GitHub Copilot CLI does not have an equivalent permission system. Its primary safeguard is the interactive confirmation prompt before executing commands, and the content exclusion settings described above (with the noted limitations).
+
+## Data handling by provider
+
+Understanding where your data goes and how it's treated is important, especially when working with client projects.
+
+| | **GitHub Copilot** | **Claude.ai (commercial)** | **OpenCode** |
+|-|-------------------|---------------------------|-------------|
+| **What's sent** | Code snippets and prompts, transmitted in real-time | Conversation text and any pasted content | Proxies through the configured provider (GitHub Copilot in our setup) |
+| **Retained?** | Not retained by default | Retained for up to 90 days for safety monitoring, then deleted | No separate retention; follows the provider's policy |
+| **Used for training?** | No | No, unless you join the [Development Partner Program](https://support.anthropic.com/en/articles/11174108-about-the-development-partner-program) | No (provider-dependent) |
+| **Key reference** | [GitHub Copilot Trust Center](https://copilot.github.trust.page), [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement) | [Anthropic Privacy Center (Commercial)](https://privacy.anthropic.com/en/articles/7996885-how-do-you-use-personal-data-in-model-training), [Trust Center](https://trust.anthropic.com/) | [OpenCode docs](https://opencode.ai/docs/) |
+
+**Important notes:**
+
+- The data handling guarantees above apply to **commercial/organization plans**. If you use Claude with a personal Free or Pro account, your conversations may be used for model training unless you disable the "Model Improvement" setting. Always use the company-provided subscription for work.
+- GitHub Copilot follows [Microsoft's Responsible AI Standard](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/final/en-us/microsoft-brand/documents/Microsoft-Responsible-AI-Standard-General-Requirements.pdf). Anthropic uses [Constitutional AI](https://www.anthropic.com/news/claudes-constitution) principles that include privacy safeguards.
+- It is the employer's responsibility to verify that provider terms are acceptable for specific client engagements. If a client has strict data residency or processing requirements, consult your team lead or the legal team before using AI tools on that project.
+
+## If something goes wrong
+
+### A credential was committed to the repository
+
+1. **Revoke or rotate the credential immediately.** Do this before anything else. The credential should be considered compromised from the moment it was pushed.
+2. **Remove it from git history.** Use [git filter-repo](https://github.com/newren/git-filter-repo) or [BFG Repo Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) to rewrite history and eliminate the secret from all commits. A force-push will be required after rewriting.
+3. **Notify the team.** Inform your team lead so they can assess whether the credential was exposed to external parties (e.g., if the repository is public or mirrored).
+4. **Check for exposure.** If the repository is hosted on GitHub, [GitHub Secret Scanning](https://docs.github.com/en/code-security/secret-scanning) may have already flagged it. Check the repository's Security tab.
+
+### Client data was included in a prompt
+
+If you accidentally pasted client PII or confidential data into a prompt:
+
+- On the **commercial Claude plan**, your data is not used for training and is deleted after the retention period (up to 90 days). However, it was still transmitted to and processed by Anthropic's servers.
+- On **GitHub Copilot**, code snippets are not retained by default.
+- In either case: **inform your team lead**, especially if the data falls under GDPR, contractual NDAs, or other regulatory obligations. The team lead will determine whether the client or legal team needs to be notified.
+
+### General principle
+
+Assume that anything sent to an AI provider has been seen by a third party. Act accordingly: rotate credentials, notify stakeholders, and document what happened. Speed matters more than perfection in incident response.
+
+## References
+
+- [GitHub Copilot Trust Center](https://copilot.github.trust.page)
+- [Excluding content from GitHub Copilot](https://docs.github.com/en/copilot/how-tos/configure-content-exclusion/exclude-content-from-copilot)
+- [GitHub Terms for Additional Products and Features](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot)
+- [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement)
+- [Responsible use of GitHub Copilot features](https://docs.github.com/en/copilot/responsible-use-of-github-copilot-features)
+- [Anthropic Privacy Center — Commercial data handling](https://privacy.anthropic.com/en/articles/7996885-how-do-you-use-personal-data-in-model-training)
+- [Anthropic Trust Center](https://trust.anthropic.com/)
+- [OpenCode Permissions](https://opencode.ai/docs/permissions)
+- [sparkdock OpenCode configuration](https://github.com/sparkfabrik/sparkdock/blob/master/config/macos/opencode.json)
+- [git filter-repo](https://github.com/newren/git-filter-repo) — for removing secrets from git history
+- [BFG Repo Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) — simpler alternative for removing secrets from git history

--- a/content/ai-development/spec-driven-development.md
+++ b/content/ai-development/spec-driven-development.md
@@ -5,9 +5,11 @@ Sort: 40
 
 ## TL;DR
 
-Write specs before code: capture intent, requirements, and design decisions in your repository before generating any code. This page explains the methodology. For commands, concepts, and file structure, see the **[OpenSpec Reference](/ai-development/openspec-reference)**.
+Write specs before code: capture intent, requirements, and design decisions in your repository before generating any code. This page explains the methodology and the reasoning behind it.
 
-New to this? Start with `/opsx:onboard` in a chat session.
+Ready to get started? Pick a framework:
+
+- **[OpenSpec](/ai-development/openspec-reference)** — our current choice, lightweight and brownfield-first
 
 ## Table of Contents
 

--- a/content/ai-development/spec-driven-development.md
+++ b/content/ai-development/spec-driven-development.md
@@ -5,14 +5,7 @@ Sort: 40
 
 ## TL;DR
 
-Write specs before code. Use OpenSpec to track changes as structured artifacts.
-
-| Step | Command | What happens |
-|------|---------|-------------|
-| Explore | `/opsx:explore` | Investigate the problem, no code written |
-| Create | `/opsx:ff <name>` | Generate proposal, specs, design, tasks |
-| Implement | `/opsx:apply` | Work through tasks one by one |
-| Finalize | `/opsx:archive` | Merge delta specs into source of truth |
+Write specs before code: capture intent, requirements, and design decisions in your repository before generating any code. This page explains the methodology. For commands, concepts, and file structure, see the **[OpenSpec Reference](/ai-development/openspec-reference)**.
 
 New to this? Start with `/opsx:onboard` in a chat session.
 

--- a/content/ai-development/spec-driven-development.md
+++ b/content/ai-development/spec-driven-development.md
@@ -3,8 +3,22 @@ Description: Spec-Driven Development with OpenSpec for AI coding assistants
 Sort: 40
 */
 
+## TL;DR
+
+Write specs before code. Use OpenSpec to track changes as structured artifacts.
+
+| Step | Command | What happens |
+|------|---------|-------------|
+| Explore | `/opsx:explore` | Investigate the problem, no code written |
+| Create | `/opsx:ff <name>` | Generate proposal, specs, design, tasks |
+| Implement | `/opsx:apply` | Work through tasks one by one |
+| Finalize | `/opsx:archive` | Merge delta specs into source of truth |
+
+New to this? Start with `/opsx:onboard` in a chat session.
+
 ## Table of Contents
 
+- [TL;DR](#tldr)
 - [What is Spec-Driven Development](#what-is-spec-driven-development)
 - [Get started](#get-started)
   - [Your first feature](#your-first-feature)

--- a/content/ai-development/spec-driven-development.md
+++ b/content/ai-development/spec-driven-development.md
@@ -9,11 +9,6 @@ Sort: 40
 - [Get started](#get-started)
   - [Your first feature](#your-first-feature)
   - [When things don't go as planned](#when-things-dont-go-as-planned)
-- [OpenSpec](#openspec)
-  - [The core flow](#the-core-flow)
-  - [Key concepts](#key-concepts)
-  - [Commands](#commands)
-  - [Project files reference](#project-files-reference)
 - [Working with Git](#working-with-git)
 - [References](#references)
 
@@ -40,6 +35,12 @@ SDD is built around a few key principles:
 - **Iterative, not waterfall**: learn as you build, refine as you go
 - **Easy, not complex**: lightweight setup, minimal ceremony
 - **Brownfield-first**: works with existing, already-running codebases, not just greenfield projects
+
+### Our current choice
+
+Spec-Driven Development is an emerging practice and the tooling around it is evolving fast. We currently use [OpenSpec](https://openspec.dev) because it aligns with our needs: lightweight, brownfield-first, tool-agnostic, and focused on specs as persistent context that live in the repository alongside code. But we're not locked in. This is an experimental field, and we will re-evaluate our approach as it matures.
+
+One alternative worth knowing about is the [BMad Method](https://docs.bmad-method.org/) (Build More Architect Dreams), an open-source AI-driven development framework that covers the full lifecycle — from brainstorming and product analysis through architecture, story breakdown, and agentic implementation — using specialized AI agents at each phase. Where OpenSpec focuses on capturing and maintaining specifications, BMad provides a broader structured workflow around the entire development process. If you've used it or want to experiment with it, bring what you learn back to the team.
 
 ### Why it matters now
 
@@ -84,7 +85,7 @@ OpenSpec works alongside the other tools in our AI stack. For details on install
 
 ### Your first feature
 
-Here is a complete example: you have a GitLab issue assigned to you and you want to implement it with OpenSpec. The workflow is **explore → create → apply → archive**.
+Here is a complete example: you have a GitLab issue assigned to you and you want to implement it with OpenSpec. The workflow is **explore -> create -> apply -> archive**.
 
 **1. Explore the issue**: understand what needs to change before writing any code:
 
@@ -163,6 +164,8 @@ AI:  Merging delta specs into openspec/specs/:
 
 Commit everything (implementation code, updated specs, and archived change artifacts) and open your merge request. Reviewers can read the spec delta to verify intent before reviewing the code.
 
+For the full list of commands, concepts, and project file structure, see the **[OpenSpec Reference](/ai-development/openspec-reference)**.
+
 ### When things don't go as planned
 
 Nothing is irreversible until you archive. If something goes wrong during implementation:
@@ -171,222 +174,6 @@ Nothing is irreversible until you archive. If something goes wrong during implem
 - **Requirements change mid-flight**: edit the spec and proposal artifacts directly (they're just Markdown files), then continue applying. The artifacts are the source of truth for the AI, so updating them updates the plan.
 - **Need to rethink the approach**: run `/opsx:explore` again at any point. You can explore as many times as you want without affecting existing artifacts.
 - **Archived too early**: the archived change is still in `openspec/changes/archive/`. You can reference it, but you'll need to create a new change to make further modifications to the specs.
-
-## OpenSpec
-
-[OpenSpec](https://github.com/Fission-AI/OpenSpec) is an open-source, tool-agnostic framework for Spec-Driven Development. It supports [multiple AI coding assistants](https://github.com/Fission-AI/OpenSpec#supported-tools): we use it with GitHub Copilot and OpenCode, but it also works with Cursor, Windsurf, Claude Code, and others.
-
-### The core flow
-
-```
-  explore ──────► create ──────► apply ──────► archive
-     │               │              │              │
-   understand      proposal       implement      merge specs
-   the problem     specs          the tasks      into source
-                   design                        of truth
-                   tasks
-```
-
-1. **Explore**: Understand the problem. Investigate the codebase, compare approaches, surface trade-offs. No code or artifacts are created yet.
-2. **Create**: Define the change. OpenSpec generates a proposal, delta specs, design, and task list. Use `/opsx:ff` to create everything at once, or `/opsx:new` + `/opsx:continue` for step-by-step control.
-3. **Apply**: Work through the implementation tasks, checking them off as you go.
-4. **Archive**: When complete, delta specs merge into the main spec library and the change moves to the archive for audit history.
-
-The flow is a recommendation, not a mandate. You can skip straight to `/opsx:ff` if you already understand the problem, or run `/opsx:explore` multiple times before creating anything. The only hard dependency is that you create a change before applying it, and apply before archiving.
-
-### Key concepts
-
-**Specs** (`openspec/specs/`) are the source of truth: they describe how the system currently behaves, organized by domain. You can inspect them with the CLI:
-
-```
-$ openspec list --specs
-Specs:
-  auth-session     requirements 2
-```
-
-A spec contains structured requirements with concrete scenarios:
-
-```markdown
-# Auth Session Specification
-
-## Purpose
-Manage user session lifecycle including creation, validation, and authentication state.
-
-## Requirements
-
-### Requirement: Session Creation
-The system SHALL create a session token upon successful authentication.
-
-#### Scenario: Successful login
-- GIVEN a user with valid credentials
-- WHEN the user submits the login form
-- THEN a session token is issued
-- AND the user is redirected to the dashboard
-```
-
-**Changes** (`openspec/changes/`) are proposed modifications. Each change is a self-contained folder with everything needed to understand and implement it:
-
-```
-openspec/changes/add-session-timeout/
-├── proposal.md           # Why and what (intent, scope, approach)
-├── design.md             # How (technical decisions, architecture)
-├── tasks.md              # Implementation checklist
-└── specs/                # Delta specs
-    └── auth-session/
-        └── spec.md       # What's changing in the auth-session spec
-```
-
-You can check the status of a change with the CLI:
-
-```
-$ openspec status --change add-session-timeout
-Change: add-session-timeout
-Schema: spec-driven
-Progress: 4/4 artifacts complete
-
-[x] proposal
-[x] design
-[x] specs
-[x] tasks
-
-All artifacts complete!
-```
-
-**Delta specs** describe what's changing relative to the current specs, using `ADDED`, `MODIFIED`, and `REMOVED` sections. This is what makes OpenSpec work well for brownfield development: you specify the change, not the entire system:
-
-```markdown
-# Delta for Auth Session
-
-## ADDED Requirements
-
-### Requirement: Session Expiration
-The system SHALL expire sessions after a configured duration of inactivity.
-
-#### Scenario: Idle timeout
-- GIVEN an authenticated user session
-- WHEN 30 minutes pass without activity
-- THEN the session token is invalidated
-- AND the user is redirected to the login page
-```
-
-**Artifacts** are the documents within a change (proposal, specs, design, tasks). They build on each other but can be updated at any time as understanding deepens.
-
-When a change is archived, its delta specs merge into the main specs. You can validate a change before archiving:
-
-```
-$ openspec validate add-session-timeout
-Change 'add-session-timeout' is valid
-```
-
-And when you archive, the delta is applied to the source of truth:
-
-```
-$ openspec archive add-session-timeout --yes
-Specs to update:
-  auth-session: update
-Applying changes to openspec/specs/auth-session/spec.md:
-  + 2 added
-Totals: + 2, ~ 0, - 0, → 0
-Specs updated successfully.
-Change 'add-session-timeout' archived as '2026-03-09-add-session-timeout'.
-```
-
-The spec now describes the new behavior (4 requirements instead of 2), and the next change builds on the updated source of truth.
-
-**Who maintains the specs?** The team that owns the domain owns its specs. Specs stay current naturally through the archive flow, since every change that touches a domain updates the relevant spec as part of its merge. If you notice a spec has drifted from reality (e.g., after a refactor that didn't use OpenSpec), update it directly or create a small change to realign it.
-
-### Commands
-
-Both GitHub Copilot and OpenCode use the same slash commands. Type them in the chat interface of either tool. Each command maps to a prompt file in your repository (under `.opencode/command/` or `.github/prompts/`) that instructs the AI what to do. You can read or customize them like any other file.
-
-**Workflow commands**, the full cycle from idea to archived specs:
-
-| Command | What it does |
-|---------|-------------|
-| `/opsx:explore` | Think through ideas, investigate the codebase, compare approaches; no code written |
-| `/opsx:ff <name>` | Create a change with all artifacts at once (proposal, specs, design, tasks) |
-| `/opsx:apply` | Implement tasks from the current change |
-| `/opsx:archive` | Archive a completed change, merging delta specs into the source of truth |
-
-**Step-by-step alternative**: use `/opsx:new` + `/opsx:continue` instead of `/opsx:ff` when you want to review and refine each artifact before moving to the next:
-
-| Command | What it does |
-|---------|-------------|
-| `/opsx:new <name>` | Scaffold a change directory and show the first artifact template |
-| `/opsx:continue` | Create the next artifact (one at a time) |
-
-**Additional commands:**
-
-| Command | What it does |
-|---------|-------------|
-| `/opsx:verify` | Check that implementation matches the specs before archiving |
-| `/opsx:sync` | Sync delta specs to main specs without archiving |
-| `/opsx:bulk-archive` | Archive multiple completed changes at once |
-| `/opsx:onboard` | Guided walkthrough of the full OpenSpec workflow; start here if you're new |
-
-**CLI commands**: the `openspec` CLI complements the slash commands with direct operations you run in your terminal:
-
-| Command | What it does |
-|---------|-------------|
-| `openspec list` | List active changes |
-| `openspec list --specs` | List specs in the source of truth |
-| `openspec status --change <name>` | Show artifact progress for a change |
-| `openspec validate <name>` | Check that a change is valid before archiving |
-| `openspec show <name>` | Display change details and artifacts |
-| `openspec archive <name>` | Archive a change, merging delta specs into the source of truth |
-| `openspec schemas` | List available workflow schemas. A schema defines which artifacts a change contains (e.g. `spec-driven` includes proposal, specs, design, tasks) |
-
-These are especially useful in CI pipelines (e.g. `openspec validate` as a pre-merge check) and for quick inspections without opening an AI chat session.
-
-Between creating and applying, review and refine the artifacts. They're just Markdown files. Edit them directly if needed. You can also run `openspec status --change <name>` at any point to check progress.
-
-### Project files reference
-
-`openspec init --tools opencode,github-copilot` creates the following files. **Commit all of them**; there is nothing to `.gitignore`.
-
-```
-your-project/
-│
-├── openspec/                          # Spec-driven development root
-│   ├── specs/                         # Source of truth (empty at init, grows as you archive)
-│   └── changes/                       # Active changes live here
-│
-├── .opencode/                         # OpenCode integration
-│   ├── command/                       # Slash commands
-│   │   ├── opsx-apply.md
-│   │   ├── opsx-archive.md
-│   │   ├── opsx-explore.md
-│   │   ├── opsx-new.md
-│   │   ├── opsx-ff.md
-│   │   ├── opsx-continue.md
-│   │   ├── opsx-verify.md
-│   │   ├── opsx-sync.md
-│   │   ├── opsx-bulk-archive.md
-│   │   └── opsx-onboard.md
-│   └── skills/                        # Skills (one folder each)
-│       ├── openspec-apply-change/
-│       ├── openspec-archive-change/
-│       ├── openspec-explore/
-│       ├── openspec-new-change/
-│       ├── openspec-ff-change/
-│       ├── openspec-continue-change/
-│       ├── openspec-verify-change/
-│       ├── openspec-sync-specs/
-│       ├── openspec-bulk-archive-change/
-│       └── openspec-onboard/
-│
-└── .github/                           # GitHub Copilot integration
-    ├── prompts/                       # Slash commands (same names, .prompt.md extension)
-    │   ├── opsx-apply.prompt.md
-    │   ├── opsx-archive.prompt.md
-    │   └── ...                        # (same set as .opencode/command/)
-    └── skills/                        # Skills (same structure as .opencode/skills/)
-        ├── openspec-apply-change/
-        ├── openspec-archive-change/
-        └── ...
-```
-
-If you use a different AI tool (Cursor, Windsurf, Claude Code), run `openspec init --tools <tool-name>` instead; see the [supported tools list](https://github.com/Fission-AI/OpenSpec#supported-tools). You can initialize multiple tools at once.
 
 ## Working with Git
 
@@ -431,4 +218,5 @@ If two developers create changes that touch the same spec domain, the second one
 - **Our blog**: [Spec-Driven Development: a practical guide](https://www.sparkfabrik.com/en/blog/spec-driven-development-guide/)
 - **OpenSpec**: [GitHub repository](https://github.com/Fission-AI/OpenSpec) and [website](https://openspec.dev)
 - **OpenSpec docs**: [Getting Started](https://github.com/Fission-AI/OpenSpec/blob/main/docs/getting-started.md), [Concepts](https://github.com/Fission-AI/OpenSpec/blob/main/docs/concepts.md), [Workflows](https://github.com/Fission-AI/OpenSpec/blob/main/docs/workflows.md), [Commands](https://github.com/Fission-AI/OpenSpec/blob/main/docs/commands.md)
+- **BMad Method**: [Documentation](https://docs.bmad-method.org/) and [GitHub repository](https://github.com/bmad-code-org/BMAD-METHOD)
 - **Agentic Engineering Patterns**: Simon Willison's guide on [working effectively with AI coding agents](https://simonwillison.net/guides/agentic-engineering-patterns/)

--- a/custom/package-lock.json
+++ b/custom/package-lock.json
@@ -4568,9 +4568,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/custom/package.json
+++ b/custom/package.json
@@ -24,6 +24,7 @@
     "patch-package": "^8.0.0"
   },
   "overrides": {
-    "glob-parent": "$glob-parent"
+    "glob-parent": "$glob-parent",
+    "path-to-regexp": "0.1.13"
   }
 }

--- a/custom/themes/spark-playbook/package-lock.json
+++ b/custom/themes/spark-playbook/package-lock.json
@@ -6636,15 +6636,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -7004,26 +6995,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/sass": {
       "version": "1.66.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
@@ -7108,13 +7079,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shallow-clone": {

--- a/custom/themes/spark-playbook/package.json
+++ b/custom/themes/spark-playbook/package.json
@@ -40,6 +40,7 @@
     "webpack-cli": "^5.1.4"
   },
   "overrides": {
-    "json5": "$json5"
+    "json5": "$json5",
+    "serialize-javascript": "7.0.5"
   }
 }


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Addresses feedback from Francesco's review of the AI Development section, plus a Node upgrade and security fixes.

### Documentation changes (Francesco's feedback)

- **Role coverage in overview.md**: Added "Beyond development" section acknowledging that current pages are developer-focused. Claude.ai is documented as the adopted tool for non-dev roles (PMs, analysts, marketing, administrative). UI/UX tooling (Google Stitch, Figma AI/Make) noted as under evaluation.
- **SDD page split**: Separated `spec-driven-development.md` into a methodology page (why SDD, walkthrough, git workflow) and a new `openspec-reference.md` page (concepts, commands, project files). Each cross-links to the other.
- **"Our current choice" note**: Added a paragraph to the SDD page acknowledging that OpenSpec is our current pick but the field is experimental. References the [BMad Method](https://docs.bmad-method.org/) as a valid alternative worth exploring.
- **Security page**: New `security.md` covering prompt hygiene, content exclusion (with the critical caveat that Copilot CLI/agent mode are not covered), agent permissions (linking [sparkdock's OpenCode config](https://github.com/sparkfabrik/sparkdock/blob/master/config/macos/opencode.json)), data handling by provider (GitHub Copilot, Claude commercial, OpenCode), and incident response procedures. All sections reference official documentation from GitHub, Anthropic, and OpenCode.
- **TL;DR sections**: Added TL;DR blocks to all three new/rewritten pages, consistent with the pattern in `tools-and-setup.md` and `skills-and-agents.md`. SDD TL;DR is framework-agnostic (links to OpenSpec reference, extensible for future frameworks). Security TL;DR notes that both Copilot (org-level) and OpenCode (sparkdock) have safe defaults configured.

### Infrastructure changes

- **Node 22 upgrade**: Dockerfile upgraded from `node:18-alpine` to `node:22-alpine` (LTS), aligning with the devcontainer which already uses Node 22.
- **Dependabot fixes**: Resolved both open alerts via npm overrides:
  - `path-to-regexp` 0.1.7 → 0.1.13 (high severity, ReDoS via multiple route parameters)
  - `serialize-javascript` 6.0.2 → 7.0.5 (medium severity, CPU exhaustion via crafted array-like objects; requires Node ≥ 20)

### Verification

- Docker image rebuilt with Node 22
- Webpack production build passes
- All playbook pages (homepage, overview, security, openspec-reference, spec-driven-development) tested locally via Playwright

## Navigation after merge

| Page | Sort | Content |
|------|------|---------|
| Where We Are | 5 | CTO letter (unchanged) |
| Overview | 10 | Stack overview + new "Beyond development" section |
| Tools and Setup | 20 | Tools and config (unchanged) |
| **Security** | **25** | **New: prompt hygiene, content exclusion, permissions, data handling** |
| Skills and Agents | 30 | Skills catalog (unchanged) |
| Spec-Driven Development | 40 | Methodology + "Our current choice" (slimmed down) |
| **OpenSpec Reference** | **45** | **New: concepts, commands, project files (moved from SDD page)** |