### PR TITLE
refs #296: Body skeleton height

### DIFF
--- a/custom/themes/spark-playbook/scss/_settings.base.scss
+++ b/custom/themes/spark-playbook/scss/_settings.base.scss
@@ -1,8 +1,12 @@
-html{
+html {
   font-size: 20px; //20px
 }
+
 body {
   padding-bottom: $height-navbar;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
Using a display:flex with direction column fix the issue and provide this result:

<img width="2124" height="876" alt="image" src="https://github.com/user-attachments/assets/9e7dc8de-d59d-421f-9afb-64fbfa185101" />
