### PR TITLE
docs(ai): migrate primary AI tooling from Copilot to Claude Code

### DIFF
--- a/content/ai-development/skills-and-agents.md
+++ b/content/ai-development/skills-and-agents.md
@@ -3,6 +3,8 @@ Description: Shared agent skills, agent profiles, and project-level resources ma
 Sort: 30
 */
 
+> **Note:** Claude Code is our primary AI coding agent. Skills and agent profiles work across Claude Code, GitHub Copilot, and OpenCode. This page covers how they are organized and shared regardless of which tool you use.
+
 ## Table of Contents
 
 - [TL;DR](#tldr)
@@ -20,11 +22,11 @@ Sort: 30
 
 ```bash
 sjust sparkdock-upgrade        # install everything
-sjust sf-agents-refresh        # sync skills and agent profiles
-sjust sf-agents-status         # verify it all landed correctly
+sjust sf-harness-sync          # sync skills and agent profiles
+sjust sf-harness-status        # verify it all landed correctly
 ```
 
-Skills and agent profiles are now available in GitHub Copilot and OpenCode. If you use VS Code, add one setting to make system agent profiles visible in the Chat view:
+Skills and agent profiles are available in Claude Code, GitHub Copilot, and OpenCode. If you use VS Code with Copilot, add one setting to make system agent profiles visible in the Chat view:
 
 ```json
 "chat.agentFilesLocations": { "~/.copilot/agents": true }
@@ -32,14 +34,17 @@ Skills and agent profiles are now available in GitHub Copilot and OpenCode. If y
 
 That's it. The rest of this page explains what skills and agent profiles are, how they're organized, and how to contribute your own.
 
+> **Note on command names:** The commands `sf-agents-refresh` and `sf-agents-status` have been renamed to `sf-harness-sync` and `sf-harness-status`. The old names may still work as aliases but new documentation uses the current names.
+
 ## What are skills and agent profiles
 
-GitHub Copilot and OpenCode are **coding agents**: AI assistants that read your code, execute multi-step tasks, and make changes. Both tools let you customize their behavior through two kinds of resources: skills and agent profiles.
+Claude Code, GitHub Copilot, and OpenCode are **coding agents**: AI assistants that read your code, execute multi-step tasks, and make changes. All three tools let you customize their behavior through two kinds of resources: skills and agent profiles.
 
-**Skills** are instruction files that teach a coding agent how to perform specific tasks: domain knowledge, tool usage patterns, safety protocols, step-by-step workflows. They follow the open [Agent Skills](https://agentskills.io) standard, supported by GitHub Copilot, OpenCode, and other tools. Each skill is a folder with a `SKILL.md` file that the agent discovers and loads on demand. See the [Agent Skills specification](https://agentskills.io/specification) for the format details.
+**Skills** are instruction files that teach a coding agent how to perform specific tasks: domain knowledge, tool usage patterns, safety protocols, step-by-step workflows. They follow the open [Agent Skills](https://agentskills.io) standard, supported by Claude Code, GitHub Copilot, OpenCode, and other tools. Each skill is a folder with a `SKILL.md` file that the agent discovers and loads on demand. See the [Agent Skills specification](https://agentskills.io/specification) for the format details.
 
-**Agent profiles** are custom agent configurations that shape how a coding agent behaves in a specific role. They can set a model preference, a system prompt, tool access rules, and a curated set of skills. For example, "the-architect" is a profile that makes the agent think like a senior software architect, focusing on design trade-offs and maintainable solutions. Both tools support this concept natively, though they use different file formats:
+**Agent profiles** are custom agent configurations that shape how a coding agent behaves in a specific role. They can set a model preference, a system prompt, tool access rules, and a curated set of skills. For example, "the-architect" is a profile that makes the agent think like a senior software architect, focusing on design trade-offs and maintainable solutions. All tools support this concept natively, though they use different file formats:
 
+- **Claude Code** calls them [agents](https://docs.anthropic.com/en/docs/claude-code/sub-agents), defined as `.md` files inside `.claude/agents/`
 - **GitHub Copilot** calls them [custom agents](https://code.visualstudio.com/docs/copilot/agents/overview), defined as `*.agent.md` files inside `.github/agents/`
 - **OpenCode** calls them [agents](https://opencode.ai/docs/agents/), configured via Markdown or JSON
 
@@ -60,16 +65,16 @@ CI/CD pipelines, and repositories.
 ...
 ```
 
-An agent profile for Copilot is an `.agent.md` file with YAML frontmatter:
+An agent profile for Claude Code is a `.md` file with YAML frontmatter:
 
 ```markdown
 ---
 name: the-architect
 description: Senior software architect focused on design trade-offs
-model: claude-sonnet-4-5
 tools:
-  - read_file
-  - search_files
+  - Read
+  - Grep
+  - Glob
 ---
 
 You are a senior software architect. Focus on system design,
@@ -82,6 +87,7 @@ maintainability, and trade-offs rather than implementation details.
 | Resource | Format docs |
 |----------|------------|
 | Skills (`SKILL.md`) | [Agent Skills specification](https://agentskills.io/specification) |
+| Claude Code agent profiles (`.md`) | [Claude Code subagents docs](https://docs.anthropic.com/en/docs/claude-code/sub-agents) |
 | Copilot agent profiles (`.agent.md`) | [VS Code custom agents docs](https://code.visualstudio.com/docs/copilot/customization/custom-agents) |
 | OpenCode agent profiles (`.md` / JSON) | [OpenCode agents docs](https://opencode.ai/docs/agents/) |
 
@@ -89,13 +95,13 @@ Note that **skills are interoperable** across tools thanks to the Agent Skills s
 
 | Scope | Resource | Location | Synced by |
 |-------|----------|----------|-----------|
-| **System** (all projects) | Skills | `~/.agents/skills/` | sparkdock (`sjust sf-agents-refresh`) |
-| **System** (all projects) | Agent profiles (Copilot) | `~/.copilot/agents/` | sparkdock (`sjust sf-agents-refresh`) |
-| **System** (all projects) | Agent profiles (OpenCode) | `~/.config/opencode/agents/` | sparkdock (`sjust sf-agents-refresh`) |
-| **Project** (one repo) | Skills | `.github/skills/` or `.opencode/skills/` | Committed in the repository |
-| **Project** (one repo) | Agent profiles | `.github/agents/` or `.claude/agents/` | Committed in the repository |
+| **System** (all projects) | Skills | `~/.agents/skills/` | sparkdock (`sjust sf-harness-sync`) |
+| **System** (all projects) | Agent profiles (Copilot) | `~/.copilot/agents/` | sparkdock (`sjust sf-harness-sync`) |
+| **System** (all projects) | Agent profiles (OpenCode) | `~/.config/opencode/agents/` | sparkdock (`sjust sf-harness-sync`) |
+| **Project** (one repo) | Skills | `.github/skills/`, `.claude/skills/`, or `.opencode/skills/` | Committed in the repository |
+| **Project** (one repo) | Agent profiles | `.claude/agents/` or `.github/agents/` | Committed in the repository |
 
-> **Why `.claude/agents/`?** VS Code reads both `.github/agents/` and `.claude/agents/` for custom agents. OpenCode uses a Markdown agent format compatible with Claude's convention, so `.claude/agents/` works as a shared path that both VS Code and OpenCode discover automatically, with no extra configuration needed. Use `.github/agents/` if you only need Copilot, or `.claude/agents/` if you want both tools to find the same files.
+> **Why `.claude/agents/`?** VS Code reads both `.github/agents/` and `.claude/agents/` for custom agents. Claude Code natively discovers agents from `.claude/agents/`. This makes `.claude/agents/` the shared path that both VS Code (via Copilot) and Claude Code discover automatically, with no extra configuration needed. Use `.github/agents/` if you only need Copilot, or `.claude/agents/` if you want both tools to find the same files.
 
 > **VS Code configuration required:** VS Code does not read `~/.copilot/agents/` by default. It discovers custom agents from `.github/agents/` (workspace), `.claude/agents/` (workspace), and the VS Code user profile folder. To make sparkdock-managed agent profiles visible in VS Code, add this to your VS Code user `settings.json`:
 >
@@ -105,9 +111,9 @@ Note that **skills are interoperable** across tools thanks to the Agent Skills s
 > }
 > ```
 >
-> This tells VS Code to also search `~/.copilot/agents/` for `.agent.md` files. Without this setting, system agent profiles will only work in Copilot CLI and OpenCode, not in VS Code chat. See the [VS Code custom agents documentation](https://code.visualstudio.com/docs/copilot/customization/custom-agents) for details.
+> This tells VS Code to also search `~/.copilot/agents/` for `.agent.md` files. Without this setting, system agent profiles will only work in Claude Code, Copilot CLI, and OpenCode, not in VS Code chat. See the [VS Code custom agents documentation](https://code.visualstudio.com/docs/copilot/customization/custom-agents) for details.
 
-> **Copilot CLI skill discovery:** Copilot CLI discovers skills from `~/.copilot/skills/`, not from the shared `~/.agents/skills/` path. Sparkdock bridges this automatically by creating per-skill symlinks in `~/.copilot/skills/` pointing to `~/.agents/skills/`. You don't need to do anything; `sjust sf-agents-refresh` takes care of it. Run `sjust sf-agents-status` to verify that managed skills show `ok` in the AVAILABLE column.
+> **Copilot CLI skill discovery:** Copilot CLI discovers skills from `~/.copilot/skills/`, not from the shared `~/.agents/skills/` path. Sparkdock bridges this automatically by creating per-skill symlinks in `~/.copilot/skills/` pointing to `~/.agents/skills/`. You don't need to do anything; `sjust sf-harness-sync` takes care of it. Run `sjust sf-harness-status` to verify that managed skills show `ok` in the AVAILABLE column.
 
 ## System skills
 
@@ -127,6 +133,7 @@ Agent profiles are synced alongside skills from sf-awesome-copilot. Each profile
 
 To use a system agent profile:
 
+- **Claude Code:** Claude Code discovers agents from `.claude/agents/` (project-level) and `~/.claude/agents/` (user-level, not sparkdock-managed). System agent profiles from sf-awesome-copilot are not auto-synced to Claude Code yet — use them via Copilot CLI or OpenCode, or manually copy them to `~/.claude/agents/`.
 - **GitHub Copilot in VS Code:** select the agent from the **agents dropdown** in the Chat view. (Type `/agents` to configure which agents appear.)
 - **GitHub Copilot CLI:** enter `/agent` in interactive mode and select from the list, or use `copilot --agent <profile-name>` in one-shot mode. The agent can also be triggered by inference from your prompt if the description matches.
 - **OpenCode:** press `Tab` to cycle through available agents in the TUI, or start a session with a specific profile: `opencode --agent <profile-name>` (or `c --agent <profile-name>`). Run `opencode agent list` to see all discovered agents.
@@ -138,7 +145,7 @@ Check the [sf-awesome-copilot repository](https://github.com/sparkfabrik/sf-awes
 ### Check status
 
 ```bash
-sjust sf-agents-status
+sjust sf-harness-status
 ```
 
 Example output:
@@ -176,16 +183,16 @@ Manifest: ~/.cache/sparkdock/sf-skills-manifest.json
 ### Sync from upstream
 
 ```bash
-sjust sf-agents-refresh
+sjust sf-harness-sync
 ```
 
 This clones (or pulls) the latest sf-awesome-copilot and syncs system resources to their local paths: skills to `~/.agents/skills/`, agent profiles to tool-specific directories (see the scope table above), and Copilot CLI symlinks to `~/.copilot/skills/`. It uses SHA256 checksums to detect changes:
 
 - If the upstream resource changed and your local copy is unmodified → **updated automatically**
 - If you modified the local copy → **skipped** (your changes are preserved)
-- To overwrite local modifications: `sjust sf-agents-refresh force`
+- To overwrite local modifications: `sjust sf-harness-sync force`
 
-> **Note:** These commands were recently renamed from `sf-skills-refresh` / `sf-skills-status`. The old names still work.
+> **Note:** These commands were recently renamed from `sf-agents-refresh` / `sf-agents-status`. The old names still work as aliases.
 
 ## Project-level skills
 
@@ -193,12 +200,13 @@ Project-level skills live in your repository and are only active when working on
 
 | Tool | Skills directory | Slash commands directory |
 |------|-----------------|------------------------|
+| Claude Code | `.claude/skills/` | `.claude/commands/` |
 | GitHub Copilot | `.github/skills/` | `.github/prompts/` |
 | OpenCode | `.opencode/skills/` | `.opencode/command/` |
 
 You don't usually create these from scratch. They come from:
 
-1. **OpenSpec:** `openspec init --tools opencode,github-copilot` generates project skills for the `/opsx:*` commands
+1. **OpenSpec:** `openspec init --tools claude,opencode,github-copilot` generates project skills for the `/opsx:*` commands
 2. **sf-awesome-copilot:** domain-specific skills that you copy into your project
 
 ## The sf-awesome-copilot repository
@@ -236,4 +244,4 @@ To add a new skill, agent profile, or project-level agent to sf-awesome-copilot:
    - `agents/<domain>/`: project-level agent definitions (manually copied)
 3. Open a pull request on the repository
 
-System skills and agent profiles (under `skills/system/` and `agents/system/`) will be automatically distributed to all developers on their next `sjust sf-agents-refresh`.
+System skills and agent profiles (under `skills/system/` and `agents/system/`) will be automatically distributed to all developers on their next `sjust sf-harness-sync`.

--- a/content/ai-development/spec-driven-development.md
+++ b/content/ai-development/spec-driven-development.md
@@ -66,18 +66,18 @@ There is also a collaboration angle. AI makes it trivially easy to generate larg
 
 ## Get started
 
-All required tools ([OpenSpec CLI](/ai-development/tools-and-setup#openspec), [GitHub Copilot CLI](/ai-development/tools-and-setup#github-copilot-cli), [OpenCode](/ai-development/tools-and-setup#opencode-experimental)) are installed automatically by [sparkdock](https://github.com/sparkfabrik/sparkdock). Run `openspec --version` to verify. If it's missing or outdated, run `sjust sparkdock-upgrade` (`sjust` is sparkdock's task runner; see [Tools and Setup](/ai-development/tools-and-setup)).
+All required tools ([OpenSpec CLI](/ai-development/tools-and-setup#openspec), [Claude Code](/ai-development/tools-and-setup#claude-code), [GitHub Copilot CLI](/ai-development/tools-and-setup#github-copilot-secondary)) are installed automatically by [sparkdock](https://github.com/sparkfabrik/sparkdock). Run `openspec --version` to verify. If it's missing or outdated, run `sjust sparkdock-upgrade` (`sjust` is sparkdock's task runner; see [Tools and Setup](/ai-development/tools-and-setup)).
 
 ### New project
 
 From the project root:
 
 ```bash
-openspec init --tools opencode,github-copilot
+openspec init --tools claude,opencode,github-copilot
 git add -A && git commit -m "chore: initialize openspec"
 ```
 
-Restart your IDE or start a new chat session. The `/opsx:*` commands work in both **GitHub Copilot** (VS Code, JetBrains) and **OpenCode** (terminal-based AI coding assistant). See [Your first feature](#your-first-feature) below for what to do next.
+Restart your IDE or start a new chat session. The `/opsx:*` commands work in **Claude Code** (primary), **GitHub Copilot** (VS Code, JetBrains), and **OpenCode** (backup). See [Your first feature](#your-first-feature) below for what to do next.
 
 ### Existing project (already has openspec/)
 
@@ -89,7 +89,7 @@ If slash commands aren't recognized, run `openspec update` to regenerate them, t
 
 OpenSpec works alongside the other tools in our AI stack. For details on installation, shell aliases, and shared skills, see:
 
-- **[Tools and Setup](/ai-development/tools-and-setup)**: GitHub Copilot CLI, OpenCode, shell aliases, sparkdock provisioning
+- **[Tools and Setup](/ai-development/tools-and-setup)**: Claude Code, GitHub Copilot, shell aliases, sparkdock provisioning
 - **[Skills and Agents](/ai-development/skills-and-agents)**: shared skills synced by sparkdock, including the glab skill used in the workflow below
 
 ### Your first feature

--- a/content/ai-development/tools-and-setup.md
+++ b/content/ai-development/tools-and-setup.md
@@ -1,5 +1,5 @@
 /*
-Description: GitHub Copilot CLI, OpenCode, shell aliases, sparkdock provisioning, and subscription policy
+Description: Claude Code, GitHub Copilot, shell aliases, sparkdock provisioning, and subscription policy
 Sort: 20
 */
 
@@ -8,12 +8,15 @@ Sort: 20
 - [TL;DR](#tldr)
 - [Overview](#overview)
   - [When to use what](#when-to-use-what)
-- [GitHub Copilot CLI](#github-copilot-cli)
-- [OpenCode (experimental)](#opencode-experimental)
+- [Claude Code](#claude-code)
+  - [IDE integration](#ide-integration)
+- [GitHub Copilot (secondary)](#github-copilot-secondary)
+- [OpenCode (backup)](#opencode-backup)
 - [OpenSpec](#openspec)
 - [Other CLI tools](#other-cli-tools)
 - [Installation and updates](#installation-and-updates)
 - [Authentication](#authentication)
+- [Claude Code subscription](#claude-code-subscription)
 - [GitHub Copilot subscription policy](#github-copilot-subscription-policy)
   - [Personal use](#personal-use)
 
@@ -29,17 +32,18 @@ sjust sparkdock-upgrade    # install all tools
 
 | What you want to do | Command |
 |---------------------|---------|
-| Quick one-shot question or task | `co "your prompt"` |
-| Sustained interactive session | `ico` |
-| OpenCode session (experimental) | `c` |
+| Start a Claude Code session (primary) | `claude` |
+| Quick one-shot task with Claude Code | `claude -p "your prompt"` |
+| Copilot one-shot (backup) | `co "your prompt"` |
+| Copilot interactive session (backup) | `ico` |
 
 **Authenticate (one-time):**
 
 | Tool | Command |
 |------|---------|
-| GitHub Copilot CLI | `copilot login` (or `/login` inside a session) |
-| OpenCode (experimental) | `/connect` in OpenCode, select "GitHub Copilot" |
-| VS Code / JetBrains | Sign in via the Copilot extension sidebar |
+| Claude Code | `claude login` |
+| GitHub Copilot CLI (backup) | `copilot login` (or `/login` inside a session) |
+| VS Code / JetBrains (Copilot autocomplete) | Sign in via the Copilot extension sidebar |
 | glab (GitLab CLI) | `sjust gitlab-configure-glab` |
 | gh (GitHub CLI) | `gh auth login` |
 
@@ -54,6 +58,7 @@ All AI development tools are installed and configured by [sparkdock](https://git
 To install or update a specific tool, use tags:
 
 ```bash
+sjust sparkdock-install-tags claude-code  # just Claude Code
 sjust sparkdock-install-tags copilot-cli  # just Copilot CLI
 sjust sparkdock-install-tags opencode     # just OpenCode
 sjust sparkdock-install-tags skills       # just shared skills
@@ -62,55 +67,98 @@ sjust sparkdock-install-tags npm_packages # just npm packages (OpenSpec, etc.)
 
 ### When to use what
 
-AI coding tools operate in two modes: **reactive** (suggest code, wait for you to apply it) and **agentic** (plan, act, observe, adjust in a loop). Both are useful. The agentic mode (where the AI reads your codebase, forms a plan, executes it, runs tests, and course-corrects) is where the biggest productivity shift is happening, and it lives primarily in the terminal.
+AI coding tools operate in two modes: **reactive** (suggest code, wait for you to apply it) and **agentic** (plan, act, observe, adjust in a loop). Both are useful. The agentic mode (where the AI reads your codebase, forms a plan, executes it, runs tests, and course-corrects) is where the biggest productivity shift is happening.
 
 | Environment | How it works | Start with |
 |-------------|-------------|------------|
-| **Copilot CLI** (terminal) | Agentic: explores your codebase, plans, executes, tests, adjusts. One-shot (`co`) for quick prompts, interactive (`ico`) for sustained work sessions. | `co "your prompt"` or `ico` for interactive |
-| **OpenCode** (terminal, experimental) | Agentic: same plan-act-observe loop, with structured workflows (OpenSpec) and full tool use. | `c` to start a session |
-| **IDE** (VS Code / JetBrains + Copilot extension) | Mixed: inline completions and chat (reactive), plus agent mode (agentic, scoped to the IDE). | Install the GitHub Copilot extension and sign in |
+| **Claude Code** (terminal, primary) | Agentic: explores your codebase, plans, executes, tests, adjusts. Full tool use, skills, subagents, and MCP integrations. | `claude` to start a session |
+| **Claude Code** (VS Code / JetBrains extension) | Agentic: same capabilities as the terminal, with native IDE integration — inline diffs, plan review, @-mentions, multiple conversation tabs. | Install the Claude Code extension |
+| **Copilot CLI** (terminal, backup) | Agentic: same plan-act-observe loop. Available for teams that prefer it or need Copilot-specific features. | `co "your prompt"` or `ico` for interactive |
+| **Copilot** (VS Code / JetBrains, autocomplete) | Reactive: inline code completions as you type. Complements Claude Code — use both together. | Install the GitHub Copilot extension and sign in |
 
-CLI agents have full terminal access, so they can run tests, check git status, install dependencies, call APIs. IDE agent mode is agentic too but sandboxed within the editor. Use the IDE for inline edits and code review; reach for a CLI agent when the task involves implementation, debugging, or anything that benefits from an autonomous work loop.
+Use Claude Code (terminal or IDE extension) as your primary agent for implementation, debugging, and any task that benefits from an autonomous work loop. Copilot's inline autocomplete complements it with real-time code suggestions as you type.
 
-## GitHub Copilot CLI
+## Claude Code
 
-[GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) is our primary AI coding assistant in the terminal. Sparkdock installs it and configures shell aliases for quick access to different models.
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) is our primary AI coding assistant in the terminal. It is Anthropic's agentic coding tool that runs the full autonomous loop: reading your codebase, planning changes, executing them, running tests, and adjusting when things fail.
 
-### One-shot mode (`co`)
-
-Send a prompt and get a single response, good for quick questions, code generation, and explanations.
-
-```bash
-co "explain what this function does" < src/auth/session.ts
-co "write unit tests for the rate limiter" < src/middleware/rate-limit.ts
-```
-
-You can pipe files into `co` via stdin or let it read your codebase from the current directory. The default model is configured by sparkdock; you can override it per-invocation with `--model`:
+**Start a session:**
 
 ```bash
-co --model claude-sonnet-4.5 "review this for security issues" < src/auth/token.ts
+claude                         # start in the current directory
+claude --agent the-architect   # start with a specific agent profile
+claude -p "your prompt"        # one-shot mode (non-interactive)
 ```
 
-### Interactive mode (`ico`)
+Claude Code uses the current directory as project context. Type `/` for slash commands (including `/opsx:*` for OpenSpec workflows).
 
-Starts a persistent chat session, good for iterative work, debugging, and multi-step tasks where you want to build on previous context.
+**What sets it apart:**
 
-```bash
-ico                    # start an interactive session
-ico --model gemini-3-pro  # start with a specific model
-```
+- **Plan mode**: press `Shift+Tab` twice to enter plan mode. Claude explores and plans without making changes. Use this for anything touching multiple files.
+- **Full tool use**: reads, edits, creates files; runs shell commands; manages git
+- **Skills and agent profiles**: loads skills from `~/.agents/skills/` (system) and `.claude/skills/` (project); agent profiles from `.claude/agents/` (project) and `~/.claude/agents/` (user)
+- **Subagents**: delegate tasks to specialized agents that run in their own context window
+- **MCP integrations**: connect to external tools (GitLab, databases, design tools) via Model Context Protocol
+- **CLAUDE.md**: project-level instructions that compound over time — every mistake becomes a rule
+- **Permission controls**: sparkdock configures rules that require confirmation before destructive operations
 
-Inside an interactive session you can use slash commands (`/help` to list them), switch models during the conversation, and reference previous responses.
+**Configuration:** Claude Code reads project instructions from `CLAUDE.md` at the repository root and from `.claude/` directory. Global configuration lives in `~/.claude/`. See the [official documentation](https://docs.anthropic.com/en/docs/claude-code/overview) for details.
 
 ### IDE integration
 
-GitHub Copilot also runs as an extension in VS Code and JetBrains IDEs, providing inline completions and a chat panel. Install it from your IDE's extension marketplace and sign in with your GitHub account.
+Claude Code also runs natively inside your IDE, providing the same agentic capabilities with a graphical interface. This is **separate from** Copilot's inline autocomplete — they complement each other:
 
-Skills and slash commands work in both the terminal CLI and the IDE extension. A skill is a set of instructions that teaches the AI how to perform a specific task (e.g., how to use glab, how to follow project conventions); a slash command triggers a specific workflow. Project-level skills go in `.github/skills/` and prompts in `.github/prompts/`.
+- **Claude Code extension** = agentic coding (plan, execute, review diffs, multi-step tasks)
+- **Copilot extension** = reactive inline completions (code suggestions as you type)
 
-## OpenCode (experimental)
+You can use both simultaneously.
 
-[OpenCode](https://opencode.ai) is an open-source, model-agnostic terminal coding agent. Like Copilot CLI, it runs the full agentic loop: reading your codebase, planning changes, executing them, running tests, and adjusting when things fail. It is currently **experimental** at SparkFabrik; we are evaluating it alongside Copilot CLI.
+#### VS Code
+
+Install the [Claude Code extension for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) (requires VS Code 1.98.0+).
+
+Key features:
+
+- **Inline diffs**: Claude shows side-by-side comparisons of proposed changes; accept, reject, or edit before applying
+- **Plan review**: in Plan mode, Claude opens the plan as a full markdown document where you can add inline comments before execution
+- **@-mentions**: reference files, folders, or line ranges (`@src/auth.ts#5-10`) for precise context
+- **Multiple conversations**: open sessions in separate tabs or windows for parallel work
+- **Session history**: resume past conversations, including remote sessions from claude.ai
+- **Keyboard shortcuts**: `Cmd+Esc` / `Ctrl+Esc` to toggle focus, `Option+K` / `Alt+K` to insert @-mention references
+
+Open Claude via the Spark icon in the editor toolbar, the Activity Bar, or the Command Palette (`Cmd+Shift+P` → "Claude Code").
+
+For the full reference, see the [Claude Code VS Code docs](https://code.claude.com/docs/en/vs-code).
+
+#### JetBrains (beta)
+
+Install the [Claude Code plugin for JetBrains](https://plugins.jetbrains.com/plugin/27310-claude-code-beta-) (IntelliJ IDEA, WebStorm, PyCharm, GoLand, and other IntelliJ-based IDEs).
+
+The plugin is currently in **beta**. It provides the same agentic workflow within the JetBrains IDE family.
+
+## GitHub Copilot (secondary)
+
+GitHub Copilot remains available as a secondary tool. Its primary value is **IDE inline autocomplete** — the real-time code suggestions that appear as you type in VS Code or JetBrains. The Copilot CLI is available as a backup terminal agent for teams that prefer it.
+
+### IDE autocomplete
+
+GitHub Copilot runs as an extension in VS Code and JetBrains IDEs, providing inline completions and a chat panel. Install it from your IDE's extension marketplace and sign in with your GitHub account. This continues to work alongside Claude Code — use Claude Code for agentic tasks in the terminal, and Copilot's inline suggestions as you type in your editor.
+
+### Copilot CLI (backup)
+
+[GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) is available for teams that still need it. Sparkdock installs it and configures shell aliases.
+
+```bash
+co "your prompt"        # one-shot mode
+ico                     # interactive mode
+ico --model gemini-3-pro  # start with a specific model
+```
+
+Skills and slash commands work in both the terminal CLI and the IDE extension.
+
+## OpenCode (backup)
+
+[OpenCode](https://opencode.ai) is an open-source, model-agnostic terminal coding agent. It is available as a backup option for teams that need model-agnostic flexibility or are still transitioning to Claude Code.
 
 **Start a session:**
 
@@ -126,7 +174,7 @@ OpenCode uses the current directory as project context. Press `Tab` to switch ag
 - **Model-agnostic**: works with Claude, GPT, Gemini, and others; no vendor lock-in
 - **Full tool use**: reads, edits, creates files; runs shell commands; manages git
 - **Skills and agent profiles**: loads from `~/.agents/skills/` (system), `.opencode/skills/` (project), and `~/.config/opencode/agents/` (agent profiles)
-- **Permission controls**: sparkdock configures rules that require confirmation before destructive operations (force-push, file deletion outside project, etc.)
+- **Permission controls**: sparkdock configures rules that require confirmation before destructive operations
 
 **Configuration:** sparkdock installs the config at `~/.config/opencode/opencode.json`. You generally don't need to edit it.
 
@@ -149,7 +197,7 @@ Sparkdock also installs CLI tools that aren't AI-specific but that the coding ag
 | **[glab](https://gitlab.com/gitlab-org/cli)** | GitLab CLI: issues, merge requests, CI/CD pipelines | `sjust gitlab-configure-glab` (one-time auth) |
 | **[gh](https://cli.github.com)** | GitHub CLI: issues, pull requests, actions, releases | `gh auth login` (one-time auth) |
 
-Both tools work standalone in your terminal and are also used by Copilot and OpenCode through skills (e.g., the [glab skill](https://github.com/sparkfabrik/sf-awesome-copilot/tree/main/skills/system/glab) lets the AI fetch issue details, read MR discussions, and check pipelines on your behalf).
+Both tools work standalone in your terminal and are also used by Claude Code and other agents through skills (e.g., the [glab skill](https://github.com/sparkfabrik/sf-awesome-copilot/tree/main/skills/system/glab) lets the AI fetch issue details, read MR discussions, and check pipelines on your behalf).
 
 ## Installation and updates
 
@@ -159,8 +207,8 @@ Everything is managed by sparkdock. Here are the commands you'll use most:
 |---------|-------------|
 | `sjust sparkdock-upgrade` | Full provisioning: installs/updates all tools |
 | `sjust sparkdock-install-tags <tag>` | Install/update specific tools by tag |
-| `sjust sf-agents-refresh` | Sync shared skills and agent profiles from upstream |
-| `sjust sf-agents-status` | Show installed skills, agent profiles, and their status |
+| `sjust sf-harness-sync` | Sync shared skills and agent profiles from upstream |
+| `sjust sf-harness-status` | Show installed skills, agent profiles, and their status |
 
 If a tool is missing or outdated, `sjust sparkdock-upgrade` is always the safe default.
 
@@ -168,16 +216,27 @@ If a tool is missing or outdated, `sjust sparkdock-upgrade` is always the safe d
 
 | Package | Source | Tag |
 |---------|--------|-----|
+| Claude Code | npm (`@anthropic-ai/claude-code`) | `claude-code` |
 | GitHub Copilot CLI | Homebrew Cask (`copilot-cli`) | `copilot-cli` |
 | OpenCode | Homebrew (`anomalyco/tap/opencode`) | `opencode` |
 | glab | Homebrew | `glab` |
 | OpenSpec | npm (`@fission-ai/openspec`) | `npm_packages` |
 
-Sparkdock also configures shell aliases, zsh completions, and OpenCode permissions.
+Sparkdock also configures shell aliases, zsh completions, and permission rules for all agents.
 
 ## Authentication
 
-All GitHub-based tools authenticate against **github.com** using your SparkFabrik organization account via OAuth. This is safe and expected. No API keys to manage manually, no third-party services. Your credentials are stored locally (in your OS keychain for Copilot CLI, in OpenCode's auth store for OpenCode).
+### Claude Code
+
+Run `claude login` from your terminal:
+
+```bash
+claude login
+```
+
+This opens your browser for authentication. Claude Code uses your Anthropic account linked to the SparkFabrik organization. The token is stored locally.
+
+For the full reference, see the official docs: [Claude Code authentication](https://docs.anthropic.com/en/docs/claude-code/overview).
 
 ### GitHub Copilot CLI
 
@@ -197,7 +256,7 @@ For the full reference, see the official docs: [Authenticating GitHub Copilot CL
 
 Sign in through the Copilot extension sidebar. It opens the same GitHub OAuth flow in your browser. Once authorized, the extension stays authenticated.
 
-### OpenCode (experimental)
+### OpenCode (backup)
 
 Open an OpenCode session (`c`), then run the `/connect` command:
 
@@ -227,7 +286,29 @@ gh auth login
 
 Select **GitHub.com**, authenticate via browser. This is also the fallback credential for Copilot CLI if `copilot login` hasn't been run.
 
+## Claude Code subscription
+
+Claude Code is provided through the SparkFabrik organization's Anthropic plan. Interactive usage (Claude Code sessions, Claude Cowork, Claude chat) consumes your plan's usage limits.
+
+### Agent SDK and headless usage
+
+Starting **June 15, 2026**, `claude -p` (headless/one-shot) and Agent SDK usage no longer count toward interactive usage limits. These get a **separate monthly credit** that refreshes with the billing cycle:
+
+| Plan | Monthly credit |
+|------|---------------|
+| Pro | $20 |
+| Max 5x | $100 |
+| Max 20x | $200 |
+| Team (Standard seats) | $20 |
+| Team (Premium seats) | $100 |
+| Enterprise (usage-based) | $20 |
+| Enterprise (seat-based Premium seats) | $200 |
+
+This means your interactive Claude Code sessions and your CI/automation (`claude -p`) pipelines have independent budgets.
+
 ## GitHub Copilot subscription policy
+
+The GitHub Copilot subscription is maintained primarily for **IDE inline autocomplete** and as a backup terminal agent. Claude Code is our primary agentic coding tool.
 
 ### Eligibility
 

--- a/content/procedures/assessing-core-skills.md
+++ b/content/procedures/assessing-core-skills.md
@@ -77,9 +77,9 @@ Everyone should have a basic understanding of:
 * **Workflow**: different branching models (git-flow, GitHub or GitLab flow), pull/merge request, peer review, squashing commits, rebase and merge, merge commits, linear history
 * **Conventions**: understand the relation between workflow-related conventions (commit granularity, versioning, commit messages format, branching model, etc.) and the working context (social contracts, environments, cadences, etc.)
 
-#### GitHub Copilot
+#### AI Coding Tools
 
-That's a "bonus track". Developers are the most impacted by the usage of Copilot, so just ask if they know what it is and if they ever tried it.
+That's a "bonus track". Developers are the most impacted by the usage of AI coding tools, so ask if they know what Claude Code (our primary agent) and GitHub Copilot (IDE autocomplete) are and if they have experience with agentic coding workflows.
 
 ### DevOps
 

--- a/content/procedures/employee-onboarding.md
+++ b/content/procedures/employee-onboarding.md
@@ -55,7 +55,7 @@ The employee must, with the help of an HR representative:
 * Duly sign in and check their ability to access every service
 * If they are a developer, ensure they are authenticated on GCP with their SparkFabrik account
 * If they are a Drupal developer, make sure [they can build FireStarter-based projects](/guides/local-development-environment-configuration#configure-firestarter-builds)
-* If they are a developer, add the user to the `Copilot members` team on GitHub and ask them to activate relevant IDE's plugins
+* If they are a developer, add the user to the `Copilot members` team on GitHub (for IDE autocomplete) and help them [set up AI development tools](/ai-development/tools-and-setup) (Claude Code as primary)
 * Activate two-factor authentication on Gitlab
 * Generate an SSH key and add it among the available keys for their Gitlab account
 * If applicable, [set up AI development tools](/ai-development/tools-and-setup) and [review the AI development overview](/ai-development/overview)

--- a/content/procedures/git-workflow.md
+++ b/content/procedures/git-workflow.md
@@ -78,7 +78,7 @@ BREAKING CHANGE: all clients must update their base URL.
 Refs: sparkfabrik/company-playbook#9876
 ```
 
-> **Tip:** Use the [SparkFabrik Copilot skill for Conventional Commits](https://github.com/sparkfabrik/sf-awesome-copilot/issues/58) to get AI-assisted commit messages locally with copilot-cli or opencode.
+> **Tip:** Use the [SparkFabrik skill for Conventional Commits](https://github.com/sparkfabrik/sf-awesome-copilot/issues/58) to get AI-assisted commit messages locally with Claude Code or other terminal agents.
 
 ### Legacy format (deprecated)
 
@@ -97,7 +97,7 @@ The old format `[#issue-id]: Commit message` (e.g. `#12345: Admins can now store
 ## Useful resources
 
 * Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/
-* SparkFabrik Copilot skill for Conventional Commits: https://github.com/sparkfabrik/sf-awesome-copilot/issues/58
+* SparkFabrik skill for Conventional Commits: https://github.com/sparkfabrik/sf-awesome-copilot/issues/58
 * Force history rewriting on push: https://www.atlassian.com/git/tutorials/rewriting-history
 * Interactive tutorials: https://ohmygit.org/ - https://learngitbranching.js.org/
 * Gitlab flow: https://docs.gitlab.com/ee/topics/gitlab_flow.html

--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -21,7 +21,7 @@ Please find here a TOC of the available training resources.
 |                   | [Networking](#networking)                               |
 | [Tools](#tools)   | [YAML](#yaml)                                           |
 |                   | [Git](#git)                                             |
-|                   | [GitHub Copilot](#github-copilot) (bonus track)         |
+|                   | [AI Coding Tools](#ai-coding-tools)                     |
 | [DevOps](#devops) | [Docker and Docker Compose](#docker-and-docker-compose) |
 |                   | [Kubernetes](#kubernetes)                               |
 |                   | [CI/CD](#cicd) (on GitLab and GitHub)                   |
@@ -107,14 +107,15 @@ All the training material in this section is public and can be freely accessed.
 |                   | [Oh my Git](https://ohmygit.org/)                                                    |
 |                   | [Visualizing Git](https://git-school.github.io/visualizing-git/)                     |
 
-### GitHub Copilot
+### AI Coding Tools
 
-> **Time to completion**: 1 hours for the documentation and installation.
+> **Time to completion**: 2 hours for documentation and setup.
 
 | Resources         |                                                                                |
 |-------------------|--------------------------------------------------------------------------------|
-| **Documentation** | [Quickstart for GitHub Copilot](https://docs.github.com/en/copilot/quickstart) |
+| **Documentation** | [Claude Code overview](https://docs.anthropic.com/en/docs/claude-code/overview) |
 |                   | [SparkFabrik's AI development tools and setup](/ai-development/tools-and-setup) |
+|                   | [Quickstart for GitHub Copilot](https://docs.github.com/en/copilot/quickstart) (IDE autocomplete) |
 
 ## DevOps
 

--- a/content/tools-and-policies/universal-dod.md
+++ b/content/tools-and-policies/universal-dod.md
@@ -49,11 +49,11 @@ When working on a SparkFabrik project, a task is considered done when:
   - Architectural overviews, schemas, flow-diagrams and decisions log.
   - Domain glossary.
   - Technical and business key contacts and roles.
-- **AI tooling prompts and instructions** are created and maintained as reusable project assets when using AI tools like GitHub Copilot, including:
-  - GitHub Copilot Custom Instructions tailored to the project's codebase and conventions.
-  - Reusable chat prompts/chat modes for common tasks (debugging, refactoring, documentation).
+- **AI tooling prompts and instructions** are created and maintained as reusable project assets when using AI tools like Claude Code, including:
+  - A `CLAUDE.md` file (or equivalent) tailored to the project's codebase and conventions.
+  - Reusable skills and slash commands for common tasks (debugging, refactoring, documentation).
   - Defined AI agents that team members can use for specific roles (e.g., "senior QA engineer", "security reviewer").
-  - An `AGENTS.md` file or similar documentation that formalizes and shares these prompts and personas with the team.
+  - An `AGENTS.md` file or similar documentation that formalizes and shares these instructions and personas with the team.
 
 #### Project-Level checks
 


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Positions **Claude Code** as the primary AI coding tool across all playbook documentation, demoting GitHub Copilot to a secondary role (IDE autocomplete + backup terminal agent for teams that need it).

Closes #304

## Changes

| File | What changed |
|------|-------------|
| `tools-and-setup.md` | Major rework: Claude Code as primary section, Copilot demoted to "secondary", OpenCode to "backup". Updated TL;DR, auth, installation tables. |
| `skills-and-agents.md` | Claude Code listed first everywhere, added Claude Code agent profile paths, updated all command names (`sf-harness-sync`/`sf-harness-status`). |
| `spec-driven-development.md` | Updated tool links and OpenSpec init command to include Claude. |
| `git-workflow.md` | Updated conventional commits tip to reference Claude Code. |
| `training-resources.md` | Renamed "GitHub Copilot" section to "AI Coding Tools", added Claude Code docs link. |
| `employee-onboarding.md` | Updated developer onboarding step to mention Claude Code as primary. |
| `assessing-core-skills.md` | Renamed "GitHub Copilot" section to "AI Coding Tools", broadened scope. |
| `universal-dod.md` | Updated DoD to reference Claude Code, `CLAUDE.md`, and skills instead of Copilot Custom Instructions. |

## What stays for Copilot

- IDE autocomplete (VS Code / JetBrains extension)
- Copilot CLI as backup for teams that need it
- Subscription policy section (updated intro to clarify reduced scope)

## Out of scope (tracked separately)

- New "Claude Code Best Practices" page (will follow in a separate PR)