### PR TITLE
docs(policies): add certification study time policy page

### DIFF
--- a/content/tools-and-policies/certification-study-time.md
+++ b/content/tools-and-policies/certification-study-time.md
@@ -1,0 +1,68 @@
+/*
+Description: How to plan and use the study time budget for certifications
+Sort: 161
+*/
+
+This page defines how we organize study time to pursue and obtain professional certifications: the yearly budget, the certification groups, the planning rules, and how we communicate during study sessions.
+
+It complements the [certified training access](/tools-and-policies/certified-training-access) policy, which defines the certifications we support, the enrollment models, and the bounties. This page covers the operating practice: how study time is planned and spent once a certification path is approved.
+
+## Guiding principles
+
+- **Study is work.** Study time is a budgeted task in the team backlog, assigned, planned and tracked like any other operational task. The backlog is what preserves the time: study hours are working hours spent on a study task, not time off.
+- **Learning comes first.** The certification is the target, but the real goal is to **acquire and retain the skills it covers**. A person who completes a study path is expected to master its key concepts, whatever the exam outcome.
+- **Sustainability.** The study load is distributed across the team over the year, so that delivery capacity is preserved.
+- **Transparency.** Study sessions are planned and visible to the whole team, through Float, the personal calendar and the Slack status.
+- **Business has priority.** Client needs and delivery priorities always take precedence. A study session yields to a real urgency and is rescheduled as soon as possible.
+
+## The study budget
+
+Each team member has a budget of **8 working days (64 hours) per year** to obtain at least one certification relevant to their role and to the team strategy.
+
+- **The exam is part of the budget.** Plan the study sessions so that enough budget remains for the exam session itself.
+- **A retake is not part of the initial budget.** If a retake is needed, it can still be planned by agreeing on the timing with the Team Leader and the Staff Engineer.
+- **The budget is not convertible.** Study hours are never treated as vacation time, even when part of the budget is left unspent.
+- **The budget is not a quota to fill.** If you can complete the path in fewer days, do so. If you expect 8 days will not be enough, raise it with your Team Leader or Staff Engineer during the path, without waiting for the budget to run out.
+
+## Certification groups
+
+The team splits into **certification groups of 2 or 3 people**. Each group consumes its study budget within a window of **at most one quarter (3 months)**.
+
+Within the window, each person allocates the 8 days, typically as 16 slots of 4 hours, concentrating them as much as possible: a steady, compact study rhythm retains knowledge better than sessions diluted over the whole year. Shorter slots (2 hours) are fine when they fit personal focus or the team plan better; how sessions are distributed is decided case by case during planning.
+
+Joining a certification group is a commitment to obtain the certification within the agreed window, putting in all the preparation needed to pass the exam. Keeping the groups small concentrates the study time of a few people without significantly reducing the capacity of the whole team.
+
+## Planning study sessions
+
+- **Plan on Float.** Each person proposes their own study blocks on Float. The plan is discussed and confirmed (or adjusted) with the Team Leader, based on the activities in progress.
+- **Mirror the plan on your calendar.** Once confirmed, set the exam date and report study and exam slots on your personal calendar as events titled "Certification", so the time is not booked by meetings or other events.
+- **Set the Slack status.** During each session, set the "Studying for Cert." custom status (the one with the books emoji). It defaults to 4 hours; adjust the duration to your slot.
+- **Announce your sessions.** At the standup, tell the team if your day includes a study session, and post in the team channel when a session starts (for example: "Starting my study slot now, back in 4 hours").
+- **Confirm a study week in advance.** A full week of study must be confirmed at the standup by the Friday morning before, so the team can coordinate around it.
+- **Keep the plan up to date.** If a session is moved by an urgency or by personal workload, recover it as soon as possible, ideally within the same week or the next, update Float and the calendar, and inform your Team Leader.
+
+## Communicating during study sessions
+
+A study session is normal work that deserves extra concentration. You stay connected and operational: Slack stays open and notifications stay on.
+
+- **Check notifications at an agreed cadence.** Instead of reacting to every ping, check your notifications at a regular interval agreed with your team, triage them, and decide what needs an answer now and what can wait for the end of the slot.
+- **Agree on overrides with your Team Leader.** Specific duties can be lifted during study sessions, such as an exemption from the team support channel, with the rest of the team covering for it.
+- **State the urgency when you contact someone who is studying.** If you ping a person with the study status on, say explicitly whether the request is urgent or can wait, so they can triage it without breaking concentration.
+- **Real emergencies go through the phone.** If something critical genuinely needs the person now, a phone call is the way to reach them.
+- **Prefer public channels.** Ask in the team channels rather than in direct messages, so anyone available can pick the request up.
+
+## Responsibilities
+
+The team member:
+
+- **defines** their certification path and gets it approved by the Team Leader and the Staff Engineer
+- **agrees** with the rest of the team on the composition and timing of the certification groups
+- **plans** the study slots, keeps Float and the personal calendar up to date, and respects the plan
+- **prepares** for the exam responsibly: obtaining the required certifications is part of the duties defined in the [certified training access](/tools-and-policies/certified-training-access) policy and is considered in the performance review
+
+The Team Leader and the Staff Engineer:
+
+- **approve** the certification paths, keeping them aligned with team and company goals
+- **organize** the backlog so that study tasks are planned and completed like any other task
+- **discuss** progress and difficulties with the team members during the path
+- **review** this practice with the team whenever needed to keep it effective

--- a/content/tools-and-policies/certification-study-time.md
+++ b/content/tools-and-policies/certification-study-time.md
@@ -12,34 +12,34 @@ It complements the [certified training access](/tools-and-policies/certified-tra
 - **Study is work.** Study time is a budgeted task in the team backlog, assigned, planned and tracked like any other operational task. The backlog is what preserves the time: study hours are working hours spent on a study task, not time off.
 - **Learning comes first.** The certification is the target, but the real goal is to **acquire and retain the skills it covers**. A person who completes a study path is expected to master its key concepts, whatever the exam outcome.
 - **Sustainability.** The study load is distributed across the team over the year, so that delivery capacity is preserved.
-- **Transparency.** Study sessions are planned and visible to the whole team, through Float, the personal calendar and the Slack status.
+- **Transparency.** Study sessions are planned and visible to the whole team, through the tracking system in use, the personal calendar and the Slack status.
 - **Business has priority.** Client needs and delivery priorities always take precedence. A study session yields to a real urgency and is rescheduled as soon as possible.
 
 ## The study budget
 
-Each team member has a budget of **8 working days (64 hours) per year** to obtain at least one certification relevant to their role and to the team strategy.
+Each team member has a **fixed yearly budget of study time**, defined with their Team Leader and tracked on the tracking system in use, to obtain at least one certification relevant to their role and to the team strategy.
 
 - **The exam is part of the budget.** Plan the study sessions so that enough budget remains for the exam session itself.
 - **A retake is not part of the initial budget.** If a retake is needed, it can still be planned by agreeing on the timing with the Team Leader and the Staff Engineer.
 - **The budget is not convertible.** Study hours are never treated as vacation time, even when part of the budget is left unspent.
-- **The budget is not a quota to fill.** If you can complete the path in fewer days, do so. If you expect 8 days will not be enough, raise it with your Team Leader or Staff Engineer during the path, without waiting for the budget to run out.
+- **The budget is not a quota to fill.** If you can complete the path in fewer days, do so. If you expect the budget will not be enough, raise it with your Team Leader or Staff Engineer during the path, without waiting for it to run out.
 
 ## Certification groups
 
 The team splits into **certification groups of 2 or 3 people**. Each group consumes its study budget within a window of **at most one quarter (3 months)**.
 
-Within the window, each person allocates the 8 days, typically as 16 slots of 4 hours, concentrating them as much as possible: a steady, compact study rhythm retains knowledge better than sessions diluted over the whole year. Shorter slots (2 hours) are fine when they fit personal focus or the team plan better; how sessions are distributed is decided case by case during planning.
+Within the window, each person allocates the budget, typically in half-day slots of 4 hours, concentrating them as much as possible: a steady, compact study rhythm retains knowledge better than sessions diluted over the whole year. Shorter slots (2 hours) are fine when they fit personal focus or the team plan better; how sessions are distributed is decided case by case during planning.
 
 Joining a certification group is a commitment to obtain the certification within the agreed window, putting in all the preparation needed to pass the exam. Keeping the groups small concentrates the study time of a few people without significantly reducing the capacity of the whole team.
 
 ## Planning study sessions
 
-- **Plan on Float.** Each person proposes their own study blocks on Float. The plan is discussed and confirmed (or adjusted) with the Team Leader, based on the activities in progress.
+- **Plan your study blocks.** Each person proposes their own study blocks on the tracking system in use. The plan is discussed and confirmed (or adjusted) with the Team Leader, based on the activities in progress.
 - **Mirror the plan on your calendar.** Once confirmed, set the exam date and report study and exam slots on your personal calendar as events titled "Certification", so the time is not booked by meetings or other events.
 - **Set the Slack status.** During each session, set the "Studying for Cert." custom status (the one with the books emoji). It defaults to 4 hours; adjust the duration to your slot.
 - **Announce your sessions.** At the standup, tell the team if your day includes a study session, and post in the team channel when a session starts (for example: "Starting my study slot now, back in 4 hours").
 - **Confirm a study week in advance.** A full week of study must be confirmed at the standup by the Friday morning before, so the team can coordinate around it.
-- **Keep the plan up to date.** If a session is moved by an urgency or by personal workload, recover it as soon as possible, ideally within the same week or the next, update Float and the calendar, and inform your Team Leader.
+- **Keep the plan up to date.** If a session is moved by an urgency or by personal workload, recover it as soon as possible, ideally within the same week or the next, update the tracking system and the calendar, and inform your Team Leader.
 
 ## Communicating during study sessions
 
@@ -57,7 +57,7 @@ The team member:
 
 - **defines** their certification path and gets it approved by the Team Leader and the Staff Engineer
 - **agrees** with the rest of the team on the composition and timing of the certification groups
-- **plans** the study slots, keeps Float and the personal calendar up to date, and respects the plan
+- **plans** the study slots, keeps the tracking system and the personal calendar up to date, and respects the plan
 - **prepares** for the exam responsibly: obtaining the required certifications is part of the duties defined in the [certified training access](/tools-and-policies/certified-training-access) policy and is considered in the performance review
 
 The Team Leader and the Staff Engineer:


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Summary

Adds `content/tools-and-policies/certification-study-time.md`, a new playbook page defining how study time for professional certifications is organized:

- **The study budget.** 8 working days (64 hours) per person per year, exam session included, retakes plannable outside the initial budget, never convertible into vacation time.
- **Certification groups.** Groups of 2 or 3 people consume their budget within at most one quarter, typically as 16 slots of 4 hours, concentrated to keep a steady study rhythm.
- **Planning.** Study blocks proposed on Float and confirmed with the Team Leader, mirrored on the personal calendar, announced at the standup, with a full study week confirmed by the Friday morning before.
- **Communication during study sessions.** Study is a budgeted backlog task: Slack stays open, notifications are checked at a cadence agreed with the team, the "Studying for Cert." status is set, overrides (such as a support channel exemption) are agreed with the Team Leader, whoever contacts a person studying states the urgency, and real emergencies go through the phone.
- **Responsibilities.** Split between the team member and the Team Leader / Staff Engineer.

## Sources

The page merges the certification study time policy v1.1 with the amendments agreed in the team retrospective of 2026-07-28 (study as a first-class backlog task, no disconnection rule, notification cadence agreed with the team, caller-stated urgency).

The page complements the existing [certified training access](https://playbook.sparkfabrik.com/tools-and-policies/certified-training-access) page (enrollment models, bounties, required certifications), which stays as is.

Refs: platform/#4725


___

### **PR Type**
Documentation


___

### **Description**
- Add new policy page for certification study time organization

- Define study budget, certification groups, and planning rules

- Establish communication guidelines during study sessions

- Outline responsibilities for team members and Team Leaders


___

### Diagram Walkthrough


```mermaid
  flowchart LR
    A["New policy page"] --> B["Study budget rules"]
    A --> C["Certification groups"]
    A --> D["Planning sessions"]
    A --> E["Communication guidelines"]
    A --> F["Responsibilities"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>certification-study-time.md</strong><dd><code>Add certification study time policy documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

content/tools-and-policies/certification-study-time.md

<ul><li>New playbook page defining certification study time policy with <br>guiding principles, budget rules, and group structure<br> <li> Specifies planning workflow using generic tracking system <br>(tool-agnostic) and personal calendar<br> <li> Details communication rules during study sessions: Slack stays open, <br>notifications checked at agreed cadence, urgency stated by callers<br> <li> Lists responsibilities for team members and Team Leader/Staff Engineer</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/company-playbook/pull/311/files#diff-165b689bb16396d8926f7fde8f99c44e9b05f72faf91b44f20ced641751c1d86">+68/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/z-ai/glm-5.2