### PR TITLE
chore(devcontainer): replace deprecated feature and extensions

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,29 +6,26 @@
     },
     "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
     "mounts": [
-        "source=projectname-bashhistory,target=/commandhistory,type=volume"
+        "source=company-playbook-bashhistory,target=/commandhistory,type=volume"
     ],
     "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
     "features": {
-        "ghcr.io/devcontainers/features/docker-from-docker:1": {}
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
     },
     "customizations": {
         "vscode": {
             "extensions": [
                 "yzhang.markdown-all-in-one",
                 "DavidAnson.vscode-markdownlint",
-                "znck.grammarly",
-                "bungcip.better-toml",
+                "streetsidesoftware.code-spell-checker",
+                "tamasfe.even-better-toml",
                 "zaaack.markdown-editor",
                 "esbenp.prettier-vscode",
                 "ms-vscode.makefile-tools"
             ],
             "settings": {
                 "editor.defaultFormatter": "esbenp.prettier-vscode",
-                "editor.formatOnSave": true,
-                "typescript.preferences.includePackageJsonAutoImports": "on",
-                "typescript.suggest.autoImports": true,
-                "javascript.suggest.autoImports": true
+                "editor.formatOnSave": true
             }
         }
     }


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Monska85._

## What

- **Renames** the `docker-from-docker` feature to `docker-outside-of-docker`, its upstream replacement with the same behavior, and commits the regenerated `devcontainer-lock.json`. The pinned digest matches what ghcr.io currently serves for tag `1` (version 1.10.0).
- **Replaces** `znck.grammarly` with `streetsidesoftware.code-spell-checker`. The Grammarly extension is abandoned and Grammarly dropped VS Code support entirely.
- **Replaces** the deprecated `bungcip.better-toml` with its official successor `tamasfe.even-better-toml`.
- **Removes** the TypeScript and JavaScript auto-import settings, which are unused in a documentation repository.
- **Renames** the bash history volume from the `projectname-bashhistory` placeholder to `company-playbook-bashhistory`.

## Why

Deprecated extensions no longer receive updates, and the old feature ID is unmaintained. The lock file was previously untracked and is now committed so feature resolution is reproducible.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Replaces deprecated `docker-from-docker` feature with `docker-outside-of-docker` and commits lock file

- Swaps abandoned extensions (`znck.grammarly`, `bungcip.better-toml`) with maintained successors

- Removes unused TypeScript and JavaScript auto-import settings

- Renames bash history volume from placeholder to `company-playbook-bashhistory`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["docker-from-docker feature"] -- "renamed to" --> B["docker-outside-of-docker"]
  C["znck.grammarly"] -- "replaced by" --> D["code-spell-checker"]
  E["bungcip.better-toml"] -- "replaced by" --> F["even-better-toml"]
  G["TS/JS auto-import settings"] -- "removed" --> H["Cleaner config"]
  I["projectname-bashhistory"] -- "renamed to" --> J["company-playbook-bashhistory"]
  B -- "pinned in" --> K["devcontainer-lock.json"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devcontainer-lock.json</strong><dd><code>Add lock file for docker-outside-of-docker feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/devcontainer-lock.json

<ul><li>Adds new lock file pinning <code>docker-outside-of-docker</code> feature to version <br><code>1.10.0</code><br> <li> Records resolved digest and integrity hash for reproducible feature <br>resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/company-playbook/pull/312/files#diff-cd9c61f8ff24fb9bcc3663e346e2cfa419cfb84e02aae18d3dc66dd192681696">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devcontainer.json</strong><dd><code>Replace deprecated feature, extensions, and clean up settings</code></dd></summary>
<hr>

.devcontainer/devcontainer.json

<ul><li>Renames <code>docker-from-docker</code> feature to <code>docker-outside-of-docker</code><br> <li> Replaces <code>znck.grammarly</code> with <code>streetsidesoftware.code-spell-checker</code><br> <li> Replaces <code>bungcip.better-toml</code> with <code>tamasfe.even-better-toml</code><br> <li> Removes unused TypeScript and JavaScript auto-import settings<br> <li> Renames bash history volume from <code>projectname-bashhistory</code> to <br><code>company-playbook-bashhistory</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/company-playbook/pull/312/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/z-ai/glm-5.2