### PR TITLE
docs(ai): make claude code the primary tool and vs code the only supported ide

### DIFF
--- a/content/FAQ/can-i-have.md
+++ b/content/FAQ/can-i-have.md
@@ -1,6 +1,6 @@
 ### Production-related equipment, hardware, software
 
-Yes. We have budgets for Linux PCs, Apple machines, PHPStorm licenses and some more gizmos that you may need.
+Yes. We have budgets for Linux PCs, Apple machines and some more gizmos that you may need.
 
 Other than that, if you need a device or license to speed up your work, just ask your team leader and we'll evaluate case by case.
 On standard hardware and software, please read [this section](/tools-and-policies/approved-hardware-and-software) to learn more.

--- a/content/ai-development/openspec-reference.md
+++ b/content/ai-development/openspec-reference.md
@@ -1,19 +1,19 @@
 /*
-Description: OpenSpec framework reference: concepts, commands, and project file structure
+Description: OpenSpec concepts, commands, and project file structure
 Sort: 45
 */
 
 ## TL;DR
 
-| What you need | Where to look |
-|---------------|---------------|
-| Workflow commands | `/opsx:explore`, `/opsx:ff`, `/opsx:apply`, `/opsx:archive` |
-| Step-by-step alternative | `/opsx:new` + `/opsx:continue` |
-| Check progress | `openspec status --change <name>` |
-| Validate before archive | `openspec validate <name>` |
-| Specs source of truth | `openspec/specs/` |
-| Active changes | `openspec/changes/` |
-| New to OpenSpec? | Start with `/opsx:onboard` in a chat session |
+| What you need            | Where to look                                                                |
+| ------------------------ | ---------------------------------------------------------------------------- |
+| Workflow commands        | `/opsx:explore`, `/opsx:propose`, `/opsx:ff`, `/opsx:apply`, `/opsx:archive` |
+| Step-by-step alternative | `/opsx:new` + `/opsx:continue`                                               |
+| Check progress           | `openspec status --change <name>`                                            |
+| Validate before archive  | `openspec validate <name>`                                                   |
+| Specs source of truth    | `openspec/specs/`                                                            |
+| Active changes           | `openspec/changes/`                                                          |
+| New to OpenSpec?         | Start with `/opsx:onboard` in a chat session                                 |
 
 ## Table of Contents
 
@@ -26,9 +26,9 @@ Sort: 45
 
 ## Overview
 
-[OpenSpec](https://github.com/Fission-AI/OpenSpec) is an open-source, tool-agnostic framework for Spec-Driven Development. It supports [multiple AI coding assistants](https://github.com/Fission-AI/OpenSpec#supported-tools): we use it with GitHub Copilot and OpenCode, but it also works with Cursor, Windsurf, Claude Code, and others.
+[OpenSpec](https://github.com/Fission-AI/OpenSpec) is an open-source, tool-agnostic framework for Spec-Driven Development. We use it with [Claude Code](/ai-development/tools-and-setup#claude-code). It also supports [other AI coding assistants](https://github.com/Fission-AI/OpenSpec#supported-tools), which matters when a project is shared with people outside the company.
 
-For the methodology behind OpenSpec — why we use specs, how they fit into our workflow, and a complete walkthrough of a feature implementation — see **[Spec-Driven Development](/ai-development/spec-driven-development)**.
+For the methodology behind OpenSpec (why we use specs, how they fit into our workflow, and a complete walkthrough of a feature implementation), see **[Spec-Driven Development](/ai-development/spec-driven-development)**.
 
 ## The core flow
 
@@ -64,14 +64,17 @@ A spec contains structured requirements with concrete scenarios:
 # Auth Session Specification
 
 ## Purpose
+
 Manage user session lifecycle including creation, validation, and authentication state.
 
 ## Requirements
 
 ### Requirement: Session Creation
+
 The system SHALL create a session token upon successful authentication.
 
 #### Scenario: Successful login
+
 - GIVEN a user with valid credentials
 - WHEN the user submits the login form
 - THEN a session token is issued
@@ -114,9 +117,11 @@ All artifacts complete!
 ## ADDED Requirements
 
 ### Requirement: Session Expiration
+
 The system SHALL expire sessions after a configured duration of inactivity.
 
 #### Scenario: Idle timeout
+
 - GIVEN an authenticated user session
 - WHEN 30 minutes pass without activity
 - THEN the session token is invalidated
@@ -151,44 +156,45 @@ The spec now describes the new behavior (4 requirements instead of 2), and the n
 
 ## Commands
 
-Both GitHub Copilot and OpenCode use the same slash commands. Type them in the chat interface of either tool. Each command maps to a prompt file in your repository (under `.opencode/command/` or `.github/prompts/`) that instructs the AI what to do. You can read or customize them like any other file.
+Type these slash commands in a Claude Code session. Each command maps to a file in your repository under `.claude/commands/opsx/` that instructs the agent what to do. You can read or customize them like any other file.
 
 **Workflow commands**, the full cycle from idea to archived specs:
 
-| Command | What it does |
-|---------|-------------|
-| `/opsx:explore` | Think through ideas, investigate the codebase, compare approaches; no code written |
-| `/opsx:ff <name>` | Create a change with all artifacts at once (proposal, specs, design, tasks) |
-| `/opsx:apply` | Implement tasks from the current change |
-| `/opsx:archive` | Archive a completed change, merging delta specs into the source of truth |
+| Command                  | What it does                                                                       |
+| ------------------------ | ---------------------------------------------------------------------------------- |
+| `/opsx:explore`          | Think through ideas, investigate the codebase, compare approaches; no code written |
+| `/opsx:propose "<idea>"` | Describe what you want and get a complete proposal with every artifact ready       |
+| `/opsx:ff <name>`        | Create a change with all artifacts at once (proposal, specs, design, tasks)        |
+| `/opsx:apply`            | Implement tasks from the current change                                            |
+| `/opsx:archive`          | Archive a completed change, merging delta specs into the source of truth           |
 
 **Step-by-step alternative**: use `/opsx:new` + `/opsx:continue` instead of `/opsx:ff` when you want to review and refine each artifact before moving to the next:
 
-| Command | What it does |
-|---------|-------------|
+| Command            | What it does                                                     |
+| ------------------ | ---------------------------------------------------------------- |
 | `/opsx:new <name>` | Scaffold a change directory and show the first artifact template |
-| `/opsx:continue` | Create the next artifact (one at a time) |
+| `/opsx:continue`   | Create the next artifact (one at a time)                         |
 
 **Additional commands:**
 
-| Command | What it does |
-|---------|-------------|
-| `/opsx:verify` | Check that implementation matches the specs before archiving |
-| `/opsx:sync` | Sync delta specs to main specs without archiving |
-| `/opsx:bulk-archive` | Archive multiple completed changes at once |
-| `/opsx:onboard` | Guided walkthrough of the full OpenSpec workflow; start here if you're new |
+| Command              | What it does                                                               |
+| -------------------- | -------------------------------------------------------------------------- |
+| `/opsx:verify`       | Check that implementation matches the specs before archiving               |
+| `/opsx:sync`         | Sync delta specs to main specs without archiving                           |
+| `/opsx:bulk-archive` | Archive multiple completed changes at once                                 |
+| `/opsx:onboard`      | Guided walkthrough of the full OpenSpec workflow; start here if you're new |
 
 **CLI commands**: the `openspec` CLI complements the slash commands with direct operations you run in your terminal:
 
-| Command | What it does |
-|---------|-------------|
-| `openspec list` | List active changes |
-| `openspec list --specs` | List specs in the source of truth |
-| `openspec status --change <name>` | Show artifact progress for a change |
-| `openspec validate <name>` | Check that a change is valid before archiving |
-| `openspec show <name>` | Display change details and artifacts |
-| `openspec archive <name>` | Archive a change, merging delta specs into the source of truth |
-| `openspec schemas` | List available workflow schemas. A schema defines which artifacts a change contains (e.g. `spec-driven` includes proposal, specs, design, tasks) |
+| Command                           | What it does                                                                                                                                     |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `openspec list`                   | List active changes                                                                                                                              |
+| `openspec list --specs`           | List specs in the source of truth                                                                                                                |
+| `openspec status --change <name>` | Show artifact progress for a change                                                                                                              |
+| `openspec validate <name>`        | Check that a change is valid before archiving                                                                                                    |
+| `openspec show <name>`            | Display change details and artifacts                                                                                                             |
+| `openspec archive <name>`         | Archive a change, merging delta specs into the source of truth                                                                                   |
+| `openspec schemas`                | List available workflow schemas. A schema defines which artifacts a change contains (e.g. `spec-driven` includes proposal, specs, design, tasks) |
 
 These are especially useful in CI pipelines (e.g. `openspec validate` as a pre-merge check) and for quick inspections without opening an AI chat session.
 
@@ -196,48 +202,42 @@ Between creating and applying, review and refine the artifacts. They're just Mar
 
 ## Project files reference
 
-`openspec init --tools opencode,github-copilot` creates the following files. **Commit all of them**; there is nothing to `.gitignore`.
+`openspec init --tools claude` creates the following files. **Commit all of them**: there is nothing to `.gitignore`.
 
-```
+```text
 your-project/
 │
 ├── openspec/                          # Spec-driven development root
+│   ├── config.yaml                    # Workflow schema and optional project context
 │   ├── specs/                         # Source of truth (empty at init, grows as you archive)
 │   └── changes/                       # Active changes live here
+│       └── archive/                   # Archived changes, dated
 │
-├── .opencode/                         # OpenCode integration
-│   ├── command/                       # Slash commands
-│   │   ├── opsx-apply.md
-│   │   ├── opsx-archive.md
-│   │   ├── opsx-explore.md
-│   │   ├── opsx-new.md
-│   │   ├── opsx-ff.md
-│   │   ├── opsx-continue.md
-│   │   ├── opsx-verify.md
-│   │   ├── opsx-sync.md
-│   │   ├── opsx-bulk-archive.md
-│   │   └── opsx-onboard.md
-│   └── skills/                        # Skills (one folder each)
-│       ├── openspec-apply-change/
-│       ├── openspec-archive-change/
-│       ├── openspec-explore/
-│       ├── openspec-new-change/
-│       ├── openspec-ff-change/
-│       ├── openspec-continue-change/
-│       ├── openspec-verify-change/
-│       ├── openspec-sync-specs/
-│       ├── openspec-bulk-archive-change/
-│       └── openspec-onboard/
-│
-└── .github/                           # GitHub Copilot integration
-    ├── prompts/                       # Slash commands (same names, .prompt.md extension)
-    │   ├── opsx-apply.prompt.md
-    │   ├── opsx-archive.prompt.md
-    │   └── ...                        # (same set as .opencode/command/)
-    └── skills/                        # Skills (same structure as .opencode/skills/)
+└── .claude/                           # Claude Code integration
+    ├── commands/opsx/                 # Slash commands, one file per /opsx: command
+    │   ├── propose.md
+    │   ├── new.md
+    │   ├── continue.md
+    │   ├── ff.md
+    │   ├── explore.md
+    │   ├── apply.md
+    │   ├── verify.md
+    │   ├── sync.md
+    │   ├── archive.md
+    │   ├── bulk-archive.md
+    │   └── onboard.md
+    └── skills/                        # Skills (one folder each, with a SKILL.md)
+        ├── openspec-propose/
+        ├── openspec-new-change/
+        ├── openspec-continue-change/
+        ├── openspec-ff-change/
+        ├── openspec-explore/
         ├── openspec-apply-change/
+        ├── openspec-verify-change/
+        ├── openspec-sync-specs/
         ├── openspec-archive-change/
-        └── ...
+        ├── openspec-bulk-archive-change/
+        └── openspec-onboard/
 ```
 
-If you use a different AI tool (Cursor, Windsurf, Claude Code), run `openspec init --tools <tool-name>` instead; see the [supported tools list](https://github.com/Fission-AI/OpenSpec#supported-tools). You can initialize multiple tools at once.
+To generate the integration for another assistant as well, pass it to the same flag (`openspec init --tools claude,cursor`); see the [supported tools list](https://github.com/Fission-AI/OpenSpec#supported-tools). You can initialize multiple tools at once.

--- a/content/ai-development/overview.md
+++ b/content/ai-development/overview.md
@@ -6,8 +6,8 @@ Sort: 10
 ## Table of Contents
 
 - [Our AI development stack](#our-ai-development-stack)
-  - [IDE](#ide)
-  - [CLI tools](#cli-tools)
+  - [Claude Code](#claude-code)
+  - [Supporting tools](#supporting-tools)
 - [How the pieces fit together](#how-the-pieces-fit-together)
 - [Beyond development](#beyond-development)
 - [Principles](#principles)
@@ -17,73 +17,82 @@ Sort: 10
 
 This section of the playbook documents where we are right now. It will change as the technology changes.
 
-For why we're investing in AI-assisted development, read [Where We Are](/ai-development/where-we-are). The rest of this page covers the practical details: [Tools and Setup](/ai-development/tools-and-setup) (what's installed and how to use it), [Skills and Agents](/ai-development/skills-and-agents) (shared resources that customize AI behavior), and [Spec-Driven Development](/ai-development/spec-driven-development) (the methodology for structured AI-assisted work).
+For why we are investing in AI-assisted development, read [Where We Are](/ai-development/where-we-are). The rest of this section covers the practical details:
 
-SparkFabrik provides AI-assisted development tools across two environments, installed and configured automatically by [sparkdock](https://github.com/sparkfabrik/sparkdock) (our workstation provisioning system).
+- **[Tools and Setup](/ai-development/tools-and-setup)** for what is installed and how to use it.
+- **[Claude Code usage and policy](/ai-development/claude-code-usage)** for usage limits, personal use, and which harnesses are authorized.
+- **[Skills and Agents](/ai-development/skills-and-agents)** for the shared resources that customize AI behavior.
+- **[Spec-Driven Development](/ai-development/spec-driven-development)** for the methodology behind structured AI-assisted work, with the [OpenSpec reference](/ai-development/openspec-reference) alongside it.
+- **[Security](/ai-development/security)** for prompt hygiene, data handling, and incident response.
 
-### IDE
+Our AI development tooling is installed and configured automatically by [sparkdock](https://github.com/sparkfabrik/sparkdock), our workstation provisioning system.
 
-[GitHub Copilot](https://docs.github.com/en/copilot) runs as an extension in **VS Code** and **JetBrains** IDEs. SparkFabrik provides a Copilot subscription through our GitHub organization. Install the extension from your IDE's marketplace and sign in with your GitHub account (see [subscription policy](/ai-development/tools-and-setup#github-copilot-subscription-policy) for details). It provides:
+### Claude Code
 
-- **Inline completions:** code suggestions as you type
-- **Chat panel:** ask questions, generate code, explain errors
-- **Agent mode:** multi-step autonomous tasks within the IDE
+[Claude Code](https://code.claude.com/docs) is our AI coding assistant. It is an agentic tool: it reads your codebase, forms a plan, executes it, runs tests, and course-corrects, rather than only suggesting code for you to apply.
 
-Project-level skills go in `.github/skills/` and prompts in `.github/prompts/`. See [Tools and Setup](/ai-development/tools-and-setup#ide-integration) for details.
+It runs in two places, with the same capabilities in both:
 
-### CLI tools
+- **The terminal.** Type `claude` in any project directory to start a session.
+- **Visual Studio Code (VS Code).** The Claude Code extension adds inline diffs, plan review, and @-mentions. VS Code is the editor we support.
 
-| Tool | What it is |
-|------|-----------|
-| **[GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)** | AI pair programmer in the terminal (alias: `co` for one-shot, `ico` for interactive) |
-| **[OpenCode](https://opencode.ai)** (experimental) | Terminal-based AI coding agent (alias: `c`) |
-| **[OpenSpec](https://openspec.dev)** | Spec-Driven Development framework: captures requirements and design as artifacts |
-| **Shared skills & agent profiles** | Reusable agent resources synced from [sf-awesome-copilot](https://github.com/sparkfabrik/sf-awesome-copilot) |
+Project-level skills go in `.claude/skills/` and agent profiles in `.claude/agents/`. See [Tools and Setup](/ai-development/tools-and-setup#ide-integration) for the setup details.
 
-Sparkdock also installs **[glab](https://gitlab.com/gitlab-org/cli)** and **[gh](https://cli.github.com)**, CLI tools for GitLab and GitHub that the AI assistants use via skills to fetch issues, read discussions, and check pipelines. See [Tools and Setup](/ai-development/tools-and-setup#other-cli-tools) for details.
+Claude Code runs on a finite usage budget shared across the organization, so knowing how the limits work is part of using the tool well. Read [Claude Code usage and policy](/ai-development/claude-code-usage) before your first heavy session.
 
-GitHub Copilot CLI is our primary terminal assistant. OpenCode is currently **experimental**; we are evaluating it as a terminal-centric alternative. Use whichever fits your workflow, or both.
+GitHub Copilot and OpenCode sit outside the standard setup and are available only for specific, agreed cases. The [support boundary](/ai-development/claude-code-usage#support-boundary) defines when.
+
+### Supporting tools
+
+| Tool                                                                               | What it is                                                                       |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **[OpenSpec](https://openspec.dev)**                                               | Spec-Driven Development framework: captures requirements and design as artifacts |
+| **Shared skills and agent profiles**                                               | Reusable agent resources synced by sparkdock from a shared catalog               |
+| **[glab](https://gitlab.com/gitlab-org/cli)** and **[gh](https://cli.github.com)** | GitLab and GitHub CLIs that the agent drives through skills                      |
+
+Sparkdock installs glab and gh so Claude Code can fetch issues, read discussions, and check pipelines on your behalf. See [Tools and Setup](/ai-development/tools-and-setup#other-cli-tools) for details.
 
 ## How the pieces fit together
 
-The tools above are general-purpose out of the box. We extend them in two ways:
+Claude Code is general-purpose out of the box. We extend it in two ways.
 
-**Skills and agent profiles** customize how the coding agents behave, adding domain knowledge, safety protocols, and role-specific configurations. SparkFabrik maintains a shared catalog in [sf-awesome-copilot](https://github.com/sparkfabrik/sf-awesome-copilot), synced to your machine automatically by sparkdock. You can also create your own, and each project can define its own alongside the code. See [Skills and Agents](/ai-development/skills-and-agents) for how they work and where they live.
+**Skills and agent profiles** customize how the agent behaves, adding domain knowledge, safety protocols, and role-specific configurations. SparkFabrik maintains a shared catalog, synced to your machine automatically by sparkdock. You can also create your own, and each project can define its own alongside the code. See [Skills and Agents](/ai-development/skills-and-agents) for how they work and where they live.
 
-**Spec-Driven Development** adds structure to how we use AI on non-trivial work. Instead of jumping straight to code, we capture intent and requirements as artifacts that the AI can reference and reviewers can verify against. See [Spec-Driven Development](/ai-development/spec-driven-development) for the methodology.
+**Spec-Driven Development** adds structure to how we use AI on non-trivial work. Instead of jumping straight to code, we capture intent and requirements as artifacts that the agent can reference and reviewers can verify against. See [Spec-Driven Development](/ai-development/spec-driven-development) for the methodology.
 
 ## Beyond development
 
-The pages in this section focus on **development workflows**: coding agents, terminal tools, and spec-driven methodologies. If you're a developer or cloud engineer, this is your starting point.
+The pages in this section focus on **development workflows**: coding agents, terminal tools, and spec-driven methodologies. If you are a developer or cloud engineer, this is your starting point.
 
-For **non-development roles** — project managers, analysts, marketing, administrative roles, and similar — **[Claude.ai](https://claude.ai)** is the AI tool we've adopted for work. It's well suited for writing, research, analysis, brainstorming, and structured thinking. Claude is provided through a company subscription; if you don't have access yet, ask your manager or reach out on `#support-hr`. Dedicated guidance for using Claude in these roles is coming.
+For **non-development roles** such as project managers, analysts, marketing, and administrative roles, [Claude.ai](https://claude.ai) is the AI tool we have adopted for work. It suits writing, research, analysis, brainstorming, and structured thinking. Claude is provided through a company subscription. If you do not have access yet, ask your manager or reach out on `#support-hr`. Dedicated guidance for these roles is coming.
 
-For **UI/UX designers**, we are evaluating specialized tools — specifically [Google Stitch](https://stitch.withgoogle.com) and [Figma AI](https://www.figma.com/ai/)/[Make](https://www.figma.com/make/) — but we haven't converged on an approach yet. If you're a designer using AI in your workflow, we'd love to hear what's working for you; your input will shape what we recommend here.
+For **UI and UX designers**, we are evaluating specialized tools, specifically [Google Stitch](https://stitch.withgoogle.com) and [Figma AI](https://www.figma.com/ai/) with [Make](https://www.figma.com/make/), but we have not converged on an approach yet. If you are a designer using AI in your workflow, we would like to hear what is working for you: your input will shape what we recommend here.
 
 ## Principles
 
 Six commitments that guide how we work with AI:
 
-**Human judgment drives the process.** AI generates, humans decide. You review every suggestion, you understand the code before it ships, and you own the result. The specs, the design decisions, the quality bar: those are yours. Don't drift into being a passenger in your own project. When the agent is doing the work, you should be doing the thinking.
+**Human judgment drives the process.** AI generates, humans decide. You review every suggestion, you understand the code before it ships, and you own the result. The specs, the design decisions, the quality bar: those are yours. Do not drift into being a passenger in your own project. When the agent is doing the work, you should be doing the thinking.
 
-**Specs before code.** When changes go beyond simple fixes (new features, architectural changes, multi-step tasks), we capture intent and requirements before generating code. This gives the AI better context, gives reviewers something to verify against, and gives future developers a record of why things are the way they are. See [Spec-Driven Development](/ai-development/spec-driven-development).
+**Specs before code.** When changes go beyond simple fixes (new features, architectural changes, multi-step tasks), we capture intent and requirements before generating code. This gives the agent better context, gives reviewers something to verify against, and gives future developers a record of why things are the way they are. See [Spec-Driven Development](/ai-development/spec-driven-development).
 
 **Minimal and battle-tested.** We curate a small set of tools and learn them deeply rather than chasing every new thing. Every tool must earn its place, and keep earning it. What we use will evolve, but by converging on a shared approach, everyone speaks the same language.
 
-**Use the approved tools for work.** The tools documented in these pages are what we use on company projects. This is how we maintain a shared language, keep knowledge transferable, and avoid fragmentation. If you think another tool deserves a spot, bring a structured proposal: what it does better, how it integrates, and what it would replace. We're open to change; we just need it to be actionable, not anecdotal.
+**Use the approved tools for work.** The tools documented in these pages are what we use on company projects. This is how we maintain a shared language, keep knowledge transferable, and avoid fragmentation. If you think another tool deserves a spot, bring a structured proposal: what it does better, how it integrates, and what it would replace. We are open to change, we just need it to be actionable rather than anecdotal.
 
-**Share what works.** When you discover a useful skill, prompt pattern, or workflow, contribute it back to [sf-awesome-copilot](https://github.com/sparkfabrik/sf-awesome-copilot) so the whole team benefits. A shared toolset means shared knowledge: what one person learns becomes available to everyone.
+**Share what works.** When you discover a useful skill, prompt pattern, or workflow, contribute it back to the shared catalog so the whole team benefits. A shared toolset means shared knowledge: what one person learns becomes available to everyone. See [Skills and Agents](/ai-development/skills-and-agents) for how to contribute.
 
-**Stay in control.** Understand what the agents have access to. Review their changes before committing. Don't grant more permissions than a task requires. When coding agents [built an entire social network](https://www.wiz.io/blog/exposed-moltbook-database-reveals-millions-of-api-keys) without human oversight, a missing configuration exposed 1.5 million API keys. Speed without review is how that happens. Autonomous agents are powerful, but autonomy without oversight is a liability.
+**Stay in control.** Understand what the agents have access to. Review their changes before committing. Do not grant more permissions than a task requires. When coding agents [built an entire social network](https://www.wiz.io/blog/exposed-moltbook-database-reveals-millions-of-api-keys) without human oversight, a missing configuration exposed 1.5 million API keys. Speed without review is how that happens. Autonomous agents are powerful, but autonomy without oversight is a liability.
 
 ## Getting started
 
-If you're new to AI-assisted development at SparkFabrik, follow the steps below. They use `sjust`, sparkdock's [just](https://github.com/casey/just)-based task runner; if you don't have it yet, run `sparkdock-upgrade` first.
+If you are new to AI-assisted development at SparkFabrik, follow the steps below. They use `sjust`, sparkdock's [just](https://github.com/casey/just)-based task runner. If you do not have it yet, run `sparkdock-upgrade` first.
 
-1. **Run `sjust sparkdock-upgrade`** to install or update all tools (Copilot CLI, OpenCode, OpenSpec, shared skills, and CLI utilities)
-2. **Read [Tools and Setup](/ai-development/tools-and-setup)** to understand what's available and how to use the shell aliases
-3. **Run `sjust sf-agents-status`** to verify that your skills and agent profiles are synced
-4. **Try it on a real task:** open VS Code with Copilot, or type `co` in your terminal for a quick one-shot prompt (or `c` to start OpenCode)
-5. **When you're ready for structured work**, read [Spec-Driven Development](/ai-development/spec-driven-development) and try the `/opsx:onboard` slash command in your AI chat session for a guided walkthrough
+1. **Run `sjust sparkdock-upgrade`** to install or update all tools: Claude Code, OpenSpec, the shared skills, and the CLI utilities.
+2. **Read [Tools and Setup](/ai-development/tools-and-setup)** to understand what is available and how to authenticate.
+3. **Read [Claude Code usage and policy](/ai-development/claude-code-usage)** so you know how the usage limits work before you hit them.
+4. **Run `sjust sf-harness-status`** to verify that your skills and agent profiles are synced.
+5. **Try it on a real task.** Type `claude` in a project directory, or open the Claude Code extension in VS Code.
+6. **When you are ready for structured work**, read [Spec-Driven Development](/ai-development/spec-driven-development) and try the `/opsx:onboard` slash command for a guided walkthrough.
 
-Existing policies like the [Merge Requests Policy](/tools-and-policies/gitlab-mr-policy) and the [Universal Definition of Done](/tools-and-policies/universal-dod) apply to AI-generated code just as they do to hand-written code. AI tools help you meet those standards; they don't exempt you from them.
+Existing policies like the [Merge Requests Policy](/tools-and-policies/gitlab-mr-policy) and the [Universal Definition of Done](/tools-and-policies/universal-dod) apply to AI-generated code just as they do to hand-written code. AI tools help you meet those standards, they do not exempt you from them.

--- a/content/ai-development/security.md
+++ b/content/ai-development/security.md
@@ -1,34 +1,34 @@
 /*
-Description: Security practices for AI-assisted development: prompt hygiene, content exclusion, data handling, and incident response
+Description: Prompt hygiene, agent permissions, data handling, and incident response for AI-assisted development
 Sort: 25
 */
 
 ## TL;DR
 
-- **Never put credentials, PII, or client secrets in prompts** — treat prompts like emails
-- **Copilot content exclusion does NOT work for CLI agents** — human review is the primary safeguard
-- **Both tools are configured with safe defaults at the org level**: GitHub Copilot has content exclusion for `.env` and sensitive paths (IDE only); OpenCode blocks `.env` files and [sparkdock](https://github.com/sparkfabrik/sparkdock/blob/master/config/macos/opencode.json) adds 150+ permission rules for destructive commands
-- **Your data is not used for training** on commercial plans (Copilot, Claude for Work)
-- **If a secret is committed**: revoke first, clean history second, notify the team
+- **Never put credentials, personal data, or client secrets in prompts.** Treat prompts like emails.
+- **Human review is the primary safeguard.** No configuration replaces reading what the agent changed before you commit it.
+- **The organization's managed policy sets the guardrails.** It read-blocks secret files and defines which operations need confirmation, and you cannot override it from a session.
+- **Your data is not used for training** on the commercial plans we use for work.
+- **If a secret is committed**: revoke first, clean history second, notify the team.
 
 ## Table of Contents
 
 - [TL;DR](#tldr)
 - [Prompt hygiene](#prompt-hygiene)
-- [Content exclusion](#content-exclusion)
 - [Agent permissions](#agent-permissions)
+- [Protecting sensitive files](#protecting-sensitive-files)
 - [Data handling by provider](#data-handling-by-provider)
 - [If something goes wrong](#if-something-goes-wrong)
 - [References](#references)
 
 ## Prompt hygiene
 
-Everything you type into an AI tool — prompt, pasted code, file content — is transmitted to a model provider. Treat prompts the way you treat emails: assume they can be read by someone outside the company.
+Everything you type into an AI tool (prompt, pasted code, file content) is transmitted to a model provider. Treat prompts the way you treat emails: assume they can be read by someone outside the company.
 
 **Never include in a prompt:**
 
 - Credentials, API keys, tokens, or passwords
-- Personally identifiable information (names, emails, phone numbers, addresses)
+- Personally identifiable information such as names, emails, phone numbers, and addresses
 - Client-confidential business logic, proprietary algorithms, or trade secrets
 - Database connection strings or infrastructure secrets
 
@@ -36,83 +36,80 @@ Everything you type into an AI tool — prompt, pasted code, file content — is
 
 - Reference files by path (`review the auth logic in src/auth/session.ts`) rather than pasting their contents, when the tool has access to your filesystem
 - Use placeholder values when describing patterns (`the API key is stored in FOO_API_KEY`)
-- If you need to share a code snippet, strip secrets first
+- Strip secrets from any snippet before sharing it
 
-This applies to all tools: GitHub Copilot (IDE and CLI), OpenCode, and Claude.ai.
-
-## Content exclusion
-
-GitHub Copilot supports [content exclusion](https://docs.github.com/en/copilot/how-tos/configure-content-exclusion/exclude-content-from-copilot) at the repository and organization level. You can configure paths that Copilot should ignore — for example, `secrets.json`, `*.env`, or entire directories containing sensitive data. This is configured in the repository settings on GitHub or in the organization's Copilot settings.
-
-However, there is a critical limitation: **content exclusion does not apply to GitHub Copilot CLI, the Copilot coding agent, or Agent mode in IDE chat**. It only works for inline completions and regular chat in the IDE. Since our primary coding workflows use CLI agents (Copilot CLI and OpenCode), content exclusion alone is not sufficient to protect sensitive files.
-
-For agentic tools, the safeguards are:
-
-- **Human review is the primary gate.** Always review agent-generated changes before committing. This is not optional; it's the most effective protection we have.
-- **OpenCode denies `.env` files by default.** OpenCode's [permission system](https://opencode.ai/docs/permissions) blocks reading `.env` and `.env.*` files out of the box. Access to directories outside the project also requires explicit approval.
-- **sparkdock configures safe defaults.** Destructive operations (force-push, file deletion outside the project, etc.) require confirmation. See [Agent permissions](#agent-permissions) below.
-- **`.gitignore` is your last line of defense.** Ensure secrets, key files, and environment configs are gitignored. If a file isn't tracked, an agent can still read it, but it won't end up in a commit unless you explicitly add it.
-
-Content exclusion is already configured at the SparkFabrik organization level for GitHub Copilot, covering `.env` files and other sensitive paths in IDE completions and chat. For additional repository-specific rules, go to the repository's **Settings > Copilot > Content exclusion** on GitHub.
+This applies to every AI tool you use for work, including Claude Code, Claude.ai, and anything running under an exception.
 
 ## Agent permissions
 
-OpenCode provides a granular [permission system](https://opencode.ai/docs/permissions) that controls what the agent can do without asking. Each action (read, edit, bash, etc.) can be set to `allow`, `ask`, or `deny`, with pattern matching for fine-grained control.
+Claude Code asks for confirmation before it acts. Each tool call (reading, editing, running a shell command) can be allowed, prompted, or denied, and the rules come from three layers: the organization's managed policy, your user settings in `~/.claude/settings.json`, and per-project settings in `.claude/settings.json`.
 
-Key defaults that [sparkdock configures](https://github.com/sparkfabrik/sparkdock/blob/master/config/macos/opencode.json):
+**The managed policy wins.** Signing in with your SparkFabrik account applies organization policy automatically. It takes absolute precedence over your user and project settings, and cannot be overridden from a session. Among other things it read-blocks secret files such as `.env`, `secrets/`, credential files, and private keys, so the agent cannot read them even if you ask it to.
 
-- `.env` and `.env.*` files: **denied** from reading
-- External directories (outside the project): require **approval**
-- Doom loop detection: if the agent repeats the same tool call three times with identical input, it pauses and asks
-- Destructive shell commands: comprehensive rules covering `rm -rf`, `sudo`, `git push --force`, `docker system prune`, `terraform destroy`, `kubectl delete`, cloud provider destructive operations (AWS, GCP, Azure), and more — each classified as either `ask` (requires confirmation) or `deny` (blocked entirely)
+For what the organization can lock and how to check what is active in your session, see [Org-managed settings](/ai-development/claude-code-usage#org-managed-settings).
 
-You can customize permissions per project (in `opencode.json`) or per agent profile (in the agent's Markdown file). For example, a read-only review agent can deny all edits:
+**Customize per project, not around the policy.** You can tighten permissions for a specific repository in `.claude/settings.json`, and restrict a subagent's tool access in its agent profile. A read-only review agent, for example, declares only the tools it needs:
 
-```yaml
-# In an agent profile
-permission:
-  edit: deny
-  bash: ask
-  webfetch: deny
+```markdown
+---
+name: reviewer
+description: Reviews code without changing it
+tools:
+  - Read
+  - Grep
+  - Glob
+---
 ```
 
-For full documentation on permission patterns, wildcards, and agent-level overrides, see the [OpenCode Permissions docs](https://opencode.ai/docs/permissions).
+Loosening the managed rules is not possible, and working around them is a policy violation rather than a configuration problem. If a rule blocks legitimate work, raise it with the platform team so the policy can change for everyone.
 
-GitHub Copilot CLI does not have an equivalent permission system. Its primary safeguard is the interactive confirmation prompt before executing commands, and the content exclusion settings described above (with the noted limitations).
+> **Note**: only the harness as provisioned by sparkdock is supported. Custom plugins, skills, agents, and MCP servers beyond that need pre-approval. See [Support boundary](/ai-development/claude-code-usage#support-boundary).
+
+## Protecting sensitive files
+
+Permission rules reduce the risk, they do not remove it. These are the safeguards that actually hold:
+
+- **Human review is the primary gate.** Always review agent-generated changes before committing. This is not optional, and it is the most effective protection we have.
+- **`.gitignore` is your last line of defense.** Keep secrets, key files, and environment configs gitignored. An agent may still read an untracked file, but it will not end up in a commit unless you explicitly add it.
+- **Keep secrets out of the working tree.** Prefer a secret manager over a local file. What is not on disk cannot be read, pasted, or committed.
+- **Scope the session.** Start the agent in the project directory rather than your home directory, so unrelated repositories and credentials are out of reach.
+
+For anyone working under a [GitHub Copilot seat exception](/ai-development/claude-code-usage#support-boundary), one limitation is worth knowing: Copilot's [content exclusion](https://docs.github.com/en/copilot/how-tos/configure-content-exclusion/exclude-content-from-copilot) applies only to inline completions and IDE chat. It does **not** apply to the Copilot CLI, the Copilot coding agent, or agent mode in IDE chat. Content exclusion is configured at the organization level for `.env` files and other sensitive paths, but do not treat it as protection for agentic work.
 
 ## Data handling by provider
 
-Understanding where your data goes and how it's treated is important, especially when working with client projects.
+Understanding where your data goes and how it is treated matters most when working with client projects.
 
-| | **GitHub Copilot** | **Claude.ai (commercial)** | **OpenCode** |
-|-|-------------------|---------------------------|-------------|
-| **What's sent** | Code snippets and prompts, transmitted in real-time | Conversation text and any pasted content | Proxies through the configured provider (GitHub Copilot in our setup) |
-| **Retained?** | Not retained by default | Retained for up to 90 days for safety monitoring, then deleted | No separate retention; follows the provider's policy |
-| **Used for training?** | No | No, unless you join the [Development Partner Program](https://support.anthropic.com/en/articles/11174108-about-the-development-partner-program) | No (provider-dependent) |
-| **Key reference** | [GitHub Copilot Trust Center](https://copilot.github.trust.page), [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement) | [Anthropic Privacy Center (Commercial)](https://privacy.anthropic.com/en/articles/7996885-how-do-you-use-personal-data-in-model-training), [Trust Center](https://trust.anthropic.com/) | [OpenCode docs](https://opencode.ai/docs/) |
+|                        | **Claude Code and Claude.ai (commercial)**                                                                                                                                 | **GitHub Copilot** (exception only)                                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **What is sent**       | Prompts, conversation text, and the file contents the agent reads or is given                                                                                              | Code snippets and prompts, transmitted in real time                                                                                                                                    |
+| **Retained?**          | Retained for a limited period for safety monitoring, then deleted                                                                                                          | Not retained by default                                                                                                                                                                |
+| **Used for training?** | No, unless you join the [Development Partner Program](https://support.anthropic.com/en/articles/11174108-about-the-development-partner-program)                            | No                                                                                                                                                                                     |
+| **Key reference**      | [Anthropic Privacy Center](https://privacy.anthropic.com/en/articles/7996885-how-do-you-use-personal-data-in-model-training), [Trust Center](https://trust.anthropic.com/) | [GitHub Copilot Trust Center](https://copilot.github.trust.page), [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement) |
 
 **Important notes:**
 
-- The data handling guarantees above apply to **commercial/organization plans**. If you use Claude with a personal Free or Pro account, your conversations may be used for model training unless you disable the "Model Improvement" setting. Always use the company-provided subscription for work.
-- GitHub Copilot follows [Microsoft's Responsible AI Standard](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/final/en-us/microsoft-brand/documents/Microsoft-Responsible-AI-Standard-General-Requirements.pdf). Anthropic uses [Constitutional AI](https://www.anthropic.com/news/claudes-constitution) principles that include privacy safeguards.
-- It is the employer's responsibility to verify that provider terms are acceptable for specific client engagements. If a client has strict data residency or processing requirements, consult your team lead or the legal team before using AI tools on that project.
+- The guarantees above apply to **commercial and organization plans**. On a personal Free or Pro Claude account, conversations may be used for model training unless you disable the model improvement setting. Always use the company-provided account for work, and keep personal work on a separate profile as described in [Profiles and multiple accounts](/ai-development/claude-code-usage#profiles-and-multiple-accounts).
+- Anthropic applies [Constitutional AI](https://www.anthropic.com/news/claudes-constitution) principles that include privacy safeguards. GitHub Copilot follows [Microsoft's Responsible AI Standard](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/final/en-us/microsoft-brand/documents/Microsoft-Responsible-AI-Standard-General-Requirements.pdf).
+- Running an agent against a personal API key puts the work outside the organization's plan, policy, and support. The [support boundary](/ai-development/claude-code-usage#support-boundary) explains why this is not allowed for work.
+- It is the employer's responsibility to verify that provider terms are acceptable for a specific client engagement. If a client has strict data residency or processing requirements, consult your team lead or the legal team before using AI tools on that project.
 
 ## If something goes wrong
 
 ### A credential was committed to the repository
 
-1. **Revoke or rotate the credential immediately.** Do this before anything else. The credential should be considered compromised from the moment it was pushed.
-2. **Remove it from git history.** Use [git filter-repo](https://github.com/newren/git-filter-repo) or [BFG Repo Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) to rewrite history and eliminate the secret from all commits. A force-push will be required after rewriting.
-3. **Notify the team.** Inform your team lead so they can assess whether the credential was exposed to external parties (e.g., if the repository is public or mirrored).
-4. **Check for exposure.** If the repository is hosted on GitHub, [GitHub Secret Scanning](https://docs.github.com/en/code-security/secret-scanning) may have already flagged it. Check the repository's Security tab.
+1. **Revoke or rotate the credential immediately.** Do this before anything else. Consider the credential compromised from the moment it was pushed.
+2. **Remove it from git history.** Use [git filter-repo](https://github.com/newren/git-filter-repo) or [BFG Repo Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) to rewrite history and eliminate the secret from all commits. A force-push is required after rewriting.
+3. **Notify the team.** Inform your team lead so they can assess whether the credential was exposed to external parties, for example if the repository is public or mirrored.
+4. **Check for exposure.** On GitHub, [secret scanning](https://docs.github.com/en/code-security/secret-scanning) may have already flagged it. Check the repository's Security tab.
 
 ### Client data was included in a prompt
 
-If you accidentally pasted client PII or confidential data into a prompt:
+If you accidentally pasted client personal data or confidential information into a prompt:
 
-- On the **commercial Claude plan**, your data is not used for training and is deleted after the retention period (up to 90 days). However, it was still transmitted to and processed by Anthropic's servers.
+- On the **commercial Claude plan**, your data is not used for training and is deleted after the retention period. It was still transmitted to and processed by Anthropic's servers.
 - On **GitHub Copilot**, code snippets are not retained by default.
-- In either case: **inform your team lead**, especially if the data falls under GDPR, contractual NDAs, or other regulatory obligations. The team lead will determine whether the client or legal team needs to be notified.
+- In either case, **inform your team lead**, especially if the data falls under the General Data Protection Regulation (GDPR), contractual non-disclosure agreements, or other regulatory obligations. The team lead determines whether the client or the legal team needs to be notified.
 
 ### General principle
 
@@ -120,14 +117,11 @@ Assume that anything sent to an AI provider has been seen by a third party. Act 
 
 ## References
 
+- [Claude Code settings](https://code.claude.com/docs/en/settings) (permission rules, precedence, lockable options)
+- [Anthropic Privacy Center, commercial data handling](https://privacy.anthropic.com/en/articles/7996885-how-do-you-use-personal-data-in-model-training)
+- [Anthropic Trust Center](https://trust.anthropic.com/)
 - [GitHub Copilot Trust Center](https://copilot.github.trust.page)
 - [Excluding content from GitHub Copilot](https://docs.github.com/en/copilot/how-tos/configure-content-exclusion/exclude-content-from-copilot)
 - [GitHub Terms for Additional Products and Features](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot)
-- [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement)
-- [Responsible use of GitHub Copilot features](https://docs.github.com/en/copilot/responsible-use-of-github-copilot-features)
-- [Anthropic Privacy Center — Commercial data handling](https://privacy.anthropic.com/en/articles/7996885-how-do-you-use-personal-data-in-model-training)
-- [Anthropic Trust Center](https://trust.anthropic.com/)
-- [OpenCode Permissions](https://opencode.ai/docs/permissions)
-- [sparkdock OpenCode configuration](https://github.com/sparkfabrik/sparkdock/blob/master/config/macos/opencode.json)
-- [git filter-repo](https://github.com/newren/git-filter-repo) — for removing secrets from git history
-- [BFG Repo Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) — simpler alternative for removing secrets from git history
+- [git filter-repo](https://github.com/newren/git-filter-repo), for removing secrets from git history
+- [BFG Repo Cleaner](https://rtyley.github.io/bfg-repo-cleaner/), a simpler alternative for the same job

--- a/content/ai-development/skills-and-agents.md
+++ b/content/ai-development/skills-and-agents.md
@@ -1,19 +1,18 @@
 /*
-Description: Shared agent skills, agent profiles, and project-level resources managed via sf-awesome-copilot
+Description: Shared agent skills, agent profiles, and project-level resources synced by sparkdock
 Sort: 30
 */
-
-> **Note:** Claude Code is our primary AI coding agent. Skills and agent profiles work across Claude Code, GitHub Copilot, and OpenCode. This page covers how they are organized and shared regardless of which tool you use.
 
 ## Table of Contents
 
 - [TL;DR](#tldr)
 - [What are skills and agent profiles](#what-are-skills-and-agent-profiles)
+- [Where they live](#where-they-live)
 - [System skills](#system-skills)
-- [System agent profiles](#system-agent-profiles)
+- [Agent profiles](#agent-profiles)
 - [Managing system resources](#managing-system-resources)
 - [Project-level skills](#project-level-skills)
-- [The sf-awesome-copilot repository](#the-sf-awesome-copilot-repository)
+- [The shared catalog](#the-shared-catalog)
 - [Contributing](#contributing)
 
 ## TL;DR
@@ -26,29 +25,15 @@ sjust sf-harness-sync          # sync skills and agent profiles
 sjust sf-harness-status        # verify it all landed correctly
 ```
 
-Skills and agent profiles are available in Claude Code, GitHub Copilot, and OpenCode. If you use VS Code with Copilot, add one setting to make system agent profiles visible in the Chat view:
-
-```json
-"chat.agentFilesLocations": { "~/.copilot/agents": true }
-```
-
-That's it. The rest of this page explains what skills and agent profiles are, how they're organized, and how to contribute your own.
-
-> **Note on command names:** The commands `sf-agents-refresh` and `sf-agents-status` have been renamed to `sf-harness-sync` and `sf-harness-status`. The old names may still work as aliases but new documentation uses the current names.
+Skills extend [Claude Code](/ai-development/tools-and-setup#claude-code) with reusable instructions, and sparkdock keeps them up to date from a shared catalog. The rest of this page explains what they are, where they live, and how to contribute your own.
 
 ## What are skills and agent profiles
 
-Claude Code, GitHub Copilot, and OpenCode are **coding agents**: AI assistants that read your code, execute multi-step tasks, and make changes. All three tools let you customize their behavior through two kinds of resources: skills and agent profiles.
+Claude Code is a **coding agent**: it reads your code, executes multi-step tasks, and makes changes. Two kinds of resource customize how it behaves.
 
-**Skills** are instruction files that teach a coding agent how to perform specific tasks: domain knowledge, tool usage patterns, safety protocols, step-by-step workflows. They follow the open [Agent Skills](https://agentskills.io) standard, supported by Claude Code, GitHub Copilot, OpenCode, and other tools. Each skill is a folder with a `SKILL.md` file that the agent discovers and loads on demand. See the [Agent Skills specification](https://agentskills.io/specification) for the format details.
+**Skills** are instruction files that teach an agent how to perform a specific task: domain knowledge, tool usage patterns, safety protocols, step-by-step workflows. They follow the open [Agent Skills](https://agentskills.io) standard, so the same skill works across tools that implement it. Each skill is a folder with a `SKILL.md` file that the agent discovers and loads on demand.
 
-**Agent profiles** are custom agent configurations that shape how a coding agent behaves in a specific role. They can set a model preference, a system prompt, tool access rules, and a curated set of skills. For example, "the-architect" is a profile that makes the agent think like a senior software architect, focusing on design trade-offs and maintainable solutions. All tools support this concept natively, though they use different file formats:
-
-- **Claude Code** calls them [agents](https://docs.anthropic.com/en/docs/claude-code/sub-agents), defined as `.md` files inside `.claude/agents/`
-- **GitHub Copilot** calls them [custom agents](https://code.visualstudio.com/docs/copilot/agents/overview), defined as `*.agent.md` files inside `.github/agents/`
-- **OpenCode** calls them [agents](https://opencode.ai/docs/agents/), configured via Markdown or JSON
-
-Agent profiles are tool-specific: the same profile name has separate definitions for each tool. [Sparkdock](https://github.com/sparkfabrik/sparkdock) and [sf-awesome-copilot](https://github.com/sparkfabrik/sf-awesome-copilot) handle the format differences; you just need to know where to put them.
+**Agent profiles** are agent configurations that shape behavior for a specific role. They can set a model preference, a system prompt, tool access rules, and a curated set of skills. A profile might make the agent think like a senior software architect, focusing on design trade-offs rather than implementation details.
 
 **What these files look like:** a skill is a folder with a `SKILL.md` file:
 
@@ -62,7 +47,6 @@ CI/CD pipelines, and repositories.
 
 - NEVER force-push to protected branches
 - ALWAYS confirm before closing or deleting issues/MRs
-...
 ```
 
 An agent profile for Claude Code is a `.md` file with YAML frontmatter:
@@ -79,66 +63,48 @@ tools:
 
 You are a senior software architect. Focus on system design,
 maintainability, and trade-offs rather than implementation details.
-...
 ```
 
 **Format references:**
 
-| Resource | Format docs |
-|----------|------------|
-| Skills (`SKILL.md`) | [Agent Skills specification](https://agentskills.io/specification) |
-| Claude Code agent profiles (`.md`) | [Claude Code subagents docs](https://docs.anthropic.com/en/docs/claude-code/sub-agents) |
-| Copilot agent profiles (`.agent.md`) | [VS Code custom agents docs](https://code.visualstudio.com/docs/copilot/customization/custom-agents) |
-| OpenCode agent profiles (`.md` / JSON) | [OpenCode agents docs](https://opencode.ai/docs/agents/) |
+| Resource               | Format docs                                                              |
+| ---------------------- | ------------------------------------------------------------------------ |
+| Skills (`SKILL.md`)    | [Agent Skills specification](https://agentskills.io/specification)       |
+| Agent profiles (`.md`) | [Claude Code subagents docs](https://code.claude.com/docs/en/sub-agents) |
 
-Note that **skills are interoperable** across tools thanks to the Agent Skills standard, but **agent profiles are not**: each tool has its own format, and there is no shared specification yet. This is why [sf-awesome-copilot](https://github.com/sparkfabrik/sf-awesome-copilot) maintains separate per-tool definitions for each profile. The emerging [AGENTS.md](https://agents.md) convention addresses a related but different need: describing a project's conventions so that *any* coding agent can work with the codebase, rather than defining reusable agent personas.
+Skills are interoperable across tools thanks to the Agent Skills standard. Agent profiles are not: each tool has its own format and there is no shared specification yet. The [AGENTS.md](https://agents.md) convention addresses a related but different need, describing a project's conventions so that any coding agent can work with the codebase, rather than defining reusable agent roles.
 
-| Scope | Resource | Location | Synced by |
-|-------|----------|----------|-----------|
-| **System** (all projects) | Skills | `~/.agents/skills/` | sparkdock (`sjust sf-harness-sync`) |
-| **System** (all projects) | Agent profiles (Copilot) | `~/.copilot/agents/` | sparkdock (`sjust sf-harness-sync`) |
-| **System** (all projects) | Agent profiles (OpenCode) | `~/.config/opencode/agents/` | sparkdock (`sjust sf-harness-sync`) |
-| **Project** (one repo) | Skills | `.github/skills/`, `.claude/skills/`, or `.opencode/skills/` | Committed in the repository |
-| **Project** (one repo) | Agent profiles | `.claude/agents/` or `.github/agents/` | Committed in the repository |
+## Where they live
 
-> **Why `.claude/agents/`?** VS Code reads both `.github/agents/` and `.claude/agents/` for custom agents. Claude Code natively discovers agents from `.claude/agents/`. This makes `.claude/agents/` the shared path that both VS Code (via Copilot) and Claude Code discover automatically, with no extra configuration needed. Use `.github/agents/` if you only need Copilot, or `.claude/agents/` if you want both tools to find the same files.
+| Scope                     | Resource       | Location            | Synced by                           |
+| ------------------------- | -------------- | ------------------- | ----------------------------------- |
+| **System** (all projects) | Skills         | `~/.agents/skills/` | sparkdock (`sjust sf-harness-sync`) |
+| **User** (all projects)   | Agent profiles | `~/.claude/agents/` | You, manually                       |
+| **Project** (one repo)    | Skills         | `.claude/skills/`   | Committed in the repository         |
+| **Project** (one repo)    | Agent profiles | `.claude/agents/`   | Committed in the repository         |
 
-> **VS Code configuration required:** VS Code does not read `~/.copilot/agents/` by default. It discovers custom agents from `.github/agents/` (workspace), `.claude/agents/` (workspace), and the VS Code user profile folder. To make sparkdock-managed agent profiles visible in VS Code, add this to your VS Code user `settings.json`:
->
-> ```json
-> "chat.agentFilesLocations": {
->   "~/.copilot/agents": true
-> }
-> ```
->
-> This tells VS Code to also search `~/.copilot/agents/` for `.agent.md` files. Without this setting, system agent profiles will only work in Claude Code, Copilot CLI, and OpenCode, not in VS Code chat. See the [VS Code custom agents documentation](https://code.visualstudio.com/docs/copilot/customization/custom-agents) for details.
-
-> **Copilot CLI skill discovery:** Copilot CLI discovers skills from `~/.copilot/skills/`, not from the shared `~/.agents/skills/` path. Sparkdock bridges this automatically by creating per-skill symlinks in `~/.copilot/skills/` pointing to `~/.agents/skills/`. You don't need to do anything; `sjust sf-harness-sync` takes care of it. Run `sjust sf-harness-status` to verify that managed skills show `ok` in the AVAILABLE column.
+Claude Code does not read `~/.agents/skills/` directly. Sparkdock bridges this by creating per-skill symlinks in `~/.claude/skills/` that point at the shared location, so system skills are discoverable in every session. You do not need to do anything: `sjust sf-harness-sync` takes care of it.
 
 ## System skills
 
-System skills are installed globally and available in every project, in every AI assistant session. [Sparkdock](https://github.com/sparkfabrik/sparkdock) syncs them from the upstream [sf-awesome-copilot](https://github.com/sparkfabrik/sf-awesome-copilot) repository.
+System skills are installed globally and available in every project, in every session. Sparkdock syncs them from the shared catalog.
 
-Currently available system skills:
+The catalog groups skills into categories. The **system** category is always installed and covers the tooling everyone shares, including the `glab` and `gh` CLI skills, the SparkFabrik commit convention and writing style, document co-authoring, and container build conventions.
 
-| Skill | What it does |
-|-------|-------------|
-| **glab** | Teaches the AI how to use the GitLab CLI: work with issues, merge requests, CI/CD pipelines. Includes a safety protocol for destructive operations. |
+Other categories are **opt-in** and cover work that only some people do, such as Angular, Drupal, Terraform, and security engagements. Enable or disable a category globally:
 
-Check the [sf-awesome-copilot repository](https://github.com/sparkfabrik/sf-awesome-copilot) for the current catalog.
+```bash
+sjust sf-harness-category enable <category>
+sjust sf-harness-category disable <category>
+```
 
-## System agent profiles
+Run `sjust sf-harness-status` to see which categories are enabled and which skills you have. For the current catalog, read the repository listed under [The shared catalog](#the-shared-catalog).
 
-Agent profiles are synced alongside skills from sf-awesome-copilot. Each profile has separate definitions for GitHub Copilot and OpenCode.
+## Agent profiles
 
-To use a system agent profile:
+Sparkdock does not sync agent profiles into Claude Code. The catalog holds domain-specific profiles that you copy into a project (or into `~/.claude/agents/` for personal use) when they are relevant.
 
-- **Claude Code:** Claude Code discovers agents from `.claude/agents/` (project-level) and `~/.claude/agents/` (user-level, not sparkdock-managed). System agent profiles from sf-awesome-copilot are not auto-synced to Claude Code yet — use them via Copilot CLI or OpenCode, or manually copy them to `~/.claude/agents/`.
-- **GitHub Copilot in VS Code:** select the agent from the **agents dropdown** in the Chat view. (Type `/agents` to configure which agents appear.)
-- **GitHub Copilot CLI:** enter `/agent` in interactive mode and select from the list, or use `copilot --agent <profile-name>` in one-shot mode. The agent can also be triggered by inference from your prompt if the description matches.
-- **OpenCode:** press `Tab` to cycle through available agents in the TUI, or start a session with a specific profile: `opencode --agent <profile-name>` (or `c --agent <profile-name>`). Run `opencode agent list` to see all discovered agents.
-
-Check the [sf-awesome-copilot repository](https://github.com/sparkfabrik/sf-awesome-copilot) for the current catalog of available agent profiles.
+Claude Code discovers profiles from `.claude/agents/` in the project and `~/.claude/agents/` for your user. Once a profile is in place, delegate to it from a session and Claude runs it as a subagent in its own context window.
 
 ## Managing system resources
 
@@ -148,37 +114,11 @@ Check the [sf-awesome-copilot repository](https://github.com/sparkfabrik/sf-awes
 sjust sf-harness-status
 ```
 
-Example output:
+The report covers the enabled skill categories, every installed skill with whether it is up to date, and the OpenSpec integration. Skills are labelled by origin:
 
-```
-╔══════════════════════════╗
-║  Agent Resources Status  ║
-╚══════════════════════════╝
-
-Skills
-╭────────────────┬────────────┬─────────────┬───────────╮
-│ NAME           │ TYPE       │ STATUS      │ AVAILABLE │
-├────────────────┼────────────┼─────────────┼───────────┤
-│ glab           │ managed    │ up to date  │ ok        │
-│ skill-creator  │ user       │             │           │
-╰────────────────┴────────────┴─────────────┴───────────╯
-
-Agent Profiles
-╭───────────────┬──────────┬─────────┬────────────╮
-│ NAME          │ TOOL     │ TYPE    │ STATUS     │
-├───────────────┼──────────┼─────────┼────────────┤
-│ the-architect │ copilot  │ managed │ up to date │
-│ the-architect │ opencode │ managed │ up to date │
-╰───────────────┴──────────┴─────────┴────────────╯
-
-Manifest: ~/.cache/sparkdock/sf-skills-manifest.json
-```
-
-- **managed**: synced from sf-awesome-copilot, updated automatically
+- **managed**: synced from the shared catalog, updated automatically
 - **user**: installed locally by you, not managed by sparkdock
 - **incomplete**: partially synced, missing required files
-- **ok** (AVAILABLE column): skill is discoverable by Copilot CLI via symlink
-- **partial** (AVAILABLE column): symlink missing or blocked; run `sjust sf-agents-refresh force` to fix
 
 ### Sync from upstream
 
@@ -186,62 +126,54 @@ Manifest: ~/.cache/sparkdock/sf-skills-manifest.json
 sjust sf-harness-sync
 ```
 
-This clones (or pulls) the latest sf-awesome-copilot and syncs system resources to their local paths: skills to `~/.agents/skills/`, agent profiles to tool-specific directories (see the scope table above), and Copilot CLI symlinks to `~/.copilot/skills/`. It uses SHA256 checksums to detect changes:
+This clones (or pulls) the latest catalog and syncs system resources to their local paths, then refreshes the symlinks that make them discoverable. It uses SHA256 checksums to detect changes:
 
-- If the upstream resource changed and your local copy is unmodified → **updated automatically**
-- If you modified the local copy → **skipped** (your changes are preserved)
-- To overwrite local modifications: `sjust sf-harness-sync force`
-
-> **Note:** These commands were recently renamed from `sf-agents-refresh` / `sf-agents-status`. The old names still work as aliases.
+- If the upstream resource changed and your local copy is unmodified, it is **updated automatically**.
+- If you modified the local copy, it is **skipped** and your changes are preserved.
+- To overwrite local modifications, run `sjust sf-harness-sync force`.
 
 ## Project-level skills
 
-Project-level skills live in your repository and are only active when working on that project. They go in different directories depending on the tool. Skills are often paired with **slash commands** (prompts); for example, OpenSpec generates both skills and `/opsx:*` commands side by side:
+Project-level skills live in your repository and are only active when working on that project. Skills are often paired with **slash commands**: OpenSpec, for example, generates both skills and the matching `/opsx:*` commands.
 
-| Tool | Skills directory | Slash commands directory |
-|------|-----------------|------------------------|
-| Claude Code | `.claude/skills/` | `.claude/commands/` |
-| GitHub Copilot | `.github/skills/` | `.github/prompts/` |
-| OpenCode | `.opencode/skills/` | `.opencode/command/` |
+| Resource       | Directory           |
+| -------------- | ------------------- |
+| Skills         | `.claude/skills/`   |
+| Slash commands | `.claude/commands/` |
+| Agent profiles | `.claude/agents/`   |
 
-You don't usually create these from scratch. They come from:
+You do not usually create these from scratch. They come from:
 
-1. **OpenSpec:** `openspec init --tools claude,opencode,github-copilot` generates project skills for the `/opsx:*` commands
-2. **sf-awesome-copilot:** domain-specific skills that you copy into your project
+1. **OpenSpec:** `openspec init --tools claude` generates the project skills and the `/opsx:*` commands.
+2. **The shared catalog:** domain-specific skills that you copy into your project.
 
-## The sf-awesome-copilot repository
+## The shared catalog
 
 **Repository:** [github.com/sparkfabrik/sf-awesome-copilot](https://github.com/sparkfabrik/sf-awesome-copilot)
 
-This is our shared catalog of skills and agent profiles. It's organized as:
+This is our shared catalog of skills and agent profiles, organized as:
 
-```
+```text
 sf-awesome-copilot/
 ├── skills/
-│   ├── system/            ← auto-synced by sparkdock to ~/.agents/skills/
-│   └── <domain>/          ← project-level, copy into your repo as needed
+│   ├── system/            # always installed, synced to ~/.agents/skills/
+│   └── <category>/        # opt-in, enabled with sf-harness-category
 ├── agents/
-│   ├── system/            ← auto-synced by sparkdock (per-tool subdirectories)
-│   │   └── <name>/
-│   │       ├── copilot/     → installed to ~/.copilot/agents/<name>.agent.md
-│   │       └── opencode/    → installed to ~/.config/opencode/agents/<name>.md
-│   └── <domain>/          ← project-level agent definitions (manually copied)
-├── AGENTS.md              ← file format specs for .agent.md and SKILL.md
-└── README.md
+│   └── <domain>/          # agent profiles, copied into projects as needed
+├── AGENTS.md              # file format specs for SKILL.md and agent profiles
+└── README.md              # the current catalog listing
 ```
 
-**System skills** (under `skills/system/`) and **system agent profiles** (under `agents/system/`) are the only ones auto-synced by sparkdock. Everything else (domain-specific skills and project-level agent definitions) is meant to be copied into individual project repositories where relevant. Check the repository's README for the current catalog of available resources.
+Skills under `skills/system/` are installed on every workstation. Everything else is either an opt-in category or a resource you copy into a project where it is relevant. Check the repository README for the current listing.
 
 ## Contributing
 
-To add a new skill, agent profile, or project-level agent to sf-awesome-copilot:
+To add a new skill or agent profile to the catalog:
 
-1. Follow the file format documented in [AGENTS.md](https://github.com/sparkfabrik/sf-awesome-copilot/blob/main/AGENTS.md)
-2. Place it in the appropriate directory:
-   - `skills/system/`: system skills (auto-synced globally)
-   - `skills/<domain>/`: project-level skills (manually copied)
-   - `agents/system/`: system agent profiles (auto-synced globally), with subdirectories for each tool (`copilot/`, `opencode/`)
-   - `agents/<domain>/`: project-level agent definitions (manually copied)
-3. Open a pull request on the repository
+1. Follow the file format documented in [AGENTS.md](https://github.com/sparkfabrik/sf-awesome-copilot/blob/main/AGENTS.md).
+2. Place it in the right directory: `skills/system/` for something everyone needs, `skills/<category>/` for domain work, `agents/<domain>/` for an agent profile.
+3. Open a pull request on the repository.
 
-System skills and agent profiles (under `skills/system/` and `agents/system/`) will be automatically distributed to all developers on their next `sjust sf-harness-sync`.
+Resources under `skills/system/` are distributed to every developer on their next `sjust sf-harness-sync`. Opt-in categories reach only the people who enabled them.
+
+When a skill or workflow proves useful, contributing it back is how the whole team gets it. That is the "share what works" principle from the [AI development overview](/ai-development/overview#principles).

--- a/content/ai-development/spec-driven-development.md
+++ b/content/ai-development/spec-driven-development.md
@@ -31,8 +31,8 @@ This is nothing different from what we already do on every project in SparkFabri
 
 A spec is a **behavior contract**: it describes what the system should do, not how it should do it internally. Compare these two ways of describing the same feature:
 
-- **Vague prompt**: *"Add session timeout so users get logged out after being idle."*
-- **Spec requirement**: *"The system SHALL expire sessions after a configured duration of inactivity. GIVEN an authenticated session, WHEN 30 minutes pass without activity, THEN the session token is invalidated AND the user is redirected to the login page."*
+- **Vague prompt**: _"Add session timeout so users get logged out after being idle."_
+- **Spec requirement**: _"The system SHALL expire sessions after a configured duration of inactivity. GIVEN an authenticated session, WHEN 30 minutes pass without activity, THEN the session token is invalidated AND the user is redirected to the login page."_
 
 The first leaves most decisions to whoever (or whatever) implements it. The second is observable, testable, and unambiguous: it uses [GIVEN/WHEN/THEN](https://martinfowler.com/bliki/GivenWhenThen.html) scenarios to make expected behavior concrete. Good specs contain behaviors, inputs, outputs, error conditions, and concrete scenarios. Implementation details like class names, library choices, or step-by-step execution plans belong in design documents and task lists, not in the spec itself.
 
@@ -55,7 +55,7 @@ One alternative worth knowing about is the [BMad Method](https://docs.bmad-metho
 
 AI coding assistants have fundamentally changed the economics of writing software. Generating hundreds of lines of code takes seconds, not hours. But this shift creates a new problem: **the bottleneck is no longer typing code; it's figuring out what to build and verifying that it's correct**.
 
-> *"Writing code is cheap now — but delivering good code remains significantly more expensive. Good code works, we know it works, it solves the right problem, it's protected by tests, and it's documented."*
+> _"Writing code is cheap now — but delivering good code remains significantly more expensive. Good code works, we know it works, it solves the right problem, it's protected by tests, and it's documented."_
 > — Simon Willison, [Agentic Engineering Patterns](https://simonwillison.net/guides/agentic-engineering-patterns/code-is-cheap/)
 
 Without specs, requirements live only in chat history. Context evaporates between sessions. A new team member (or even you, two weeks later) has no record of what the system is supposed to do or why a decision was made. AI agents become unpredictable when the only input is a vague prompt and a codebase with no documented intent.
@@ -66,18 +66,18 @@ There is also a collaboration angle. AI makes it trivially easy to generate larg
 
 ## Get started
 
-All required tools ([OpenSpec CLI](/ai-development/tools-and-setup#openspec), [Claude Code](/ai-development/tools-and-setup#claude-code), [GitHub Copilot CLI](/ai-development/tools-and-setup#github-copilot-secondary)) are installed automatically by [sparkdock](https://github.com/sparkfabrik/sparkdock). Run `openspec --version` to verify. If it's missing or outdated, run `sjust sparkdock-upgrade` (`sjust` is sparkdock's task runner; see [Tools and Setup](/ai-development/tools-and-setup)).
+Both required tools, the [OpenSpec CLI](/ai-development/tools-and-setup#openspec) and [Claude Code](/ai-development/tools-and-setup#claude-code), are installed automatically by [sparkdock](https://github.com/sparkfabrik/sparkdock). Run `openspec --version` to verify. If it's missing or outdated, run `sjust sparkdock-upgrade` (`sjust` is sparkdock's task runner; see [Tools and Setup](/ai-development/tools-and-setup)).
 
 ### New project
 
 From the project root:
 
 ```bash
-openspec init --tools claude,opencode,github-copilot
+openspec init --tools claude
 git add -A && git commit -m "chore: initialize openspec"
 ```
 
-Restart your IDE or start a new chat session. The `/opsx:*` commands work in **Claude Code** (primary), **GitHub Copilot** (VS Code, JetBrains), and **OpenCode** (backup). See [Your first feature](#your-first-feature) below for what to do next.
+Start a new Claude Code session so it picks up the generated commands. See [Your first feature](#your-first-feature) below for what to do next.
 
 ### Existing project (already has openspec/)
 
@@ -89,7 +89,7 @@ If slash commands aren't recognized, run `openspec update` to regenerate them, t
 
 OpenSpec works alongside the other tools in our AI stack. For details on installation, shell aliases, and shared skills, see:
 
-- **[Tools and Setup](/ai-development/tools-and-setup)**: Claude Code, GitHub Copilot, shell aliases, sparkdock provisioning
+- **[Tools and Setup](/ai-development/tools-and-setup)**: Claude Code installation, authentication, and sparkdock provisioning
 - **[Skills and Agents](/ai-development/skills-and-agents)**: shared skills synced by sparkdock, including the glab skill used in the workflow below
 
 ### Your first feature
@@ -213,6 +213,7 @@ Everything under `openspec/` should be committed. There is nothing to `.gitignor
 When you open a merge request, reviewers can look at the spec delta **before** reading the code. This is especially valuable for AI-generated code: the spec explains what the change is supposed to do, so the reviewer can verify intent instead of reverse-engineering it from the diff.
 
 Link the change artifacts in your MR description. If you archive before merging, the paths will be under `openspec/changes/archive/`:
+
 ```
 ## OpenSpec change
 See `openspec/changes/archive/2026-03-09-add-session-timeout/proposal.md` for intent and scope.

--- a/content/ai-development/tools-and-setup.md
+++ b/content/ai-development/tools-and-setup.md
@@ -1,7 +1,7 @@
-/_
+/*
 Description: Claude Code, GitHub Copilot, shell aliases, sparkdock provisioning, and subscription policy
 Sort: 20
-_/
+*/
 
 ## Table of Contents
 

--- a/content/ai-development/tools-and-setup.md
+++ b/content/ai-development/tools-and-setup.md
@@ -1,5 +1,5 @@
 /*
-Description: Claude Code, GitHub Copilot, shell aliases, sparkdock provisioning, and subscription policy
+Description: Claude Code installation, authentication, shell aliases, sparkdock provisioning, and subscriptions
 Sort: 20
 */
 
@@ -7,20 +7,22 @@ Sort: 20
 
 - [TL;DR](#tldr)
 - [Overview](#overview)
-  - [When to use what](#when-to-use-what)
+  - [Reactive and agentic modes](#reactive-and-agentic-modes)
 - [Claude Code](#claude-code)
   - [IDE integration](#ide-integration)
-- [GitHub Copilot (secondary)](#github-copilot-secondary)
-- [OpenCode (backup)](#opencode-backup)
+- [Exceptions: Copilot and OpenCode](#exceptions-copilot-and-opencode)
 - [OpenSpec](#openspec)
 - [Other CLI tools](#other-cli-tools)
 - [Installation and updates](#installation-and-updates)
 - [Authentication](#authentication)
 - [Claude Code subscription](#claude-code-subscription)
-- [GitHub Copilot subscription policy](#github-copilot-subscription-policy)
+  - [Agent SDK and headless usage](#agent-sdk-and-headless-usage)
+- [GitHub Copilot seats](#github-copilot-seats)
   - [Personal use](#personal-use)
 
 ## TL;DR
+
+Claude Code is the AI coding assistant we use, in the terminal and in Visual Studio Code (VS Code). VS Code is the editor we support.
 
 **Get up and running:**
 
@@ -30,26 +32,20 @@ sjust sparkdock-upgrade    # install all tools
 
 **Start coding with AI:**
 
-| What you want to do                   | Command                   |
-| ------------------------------------- | ------------------------- |
-| Start a Claude Code session (primary) | `claude`                  |
-| Quick one-shot task with Claude Code  | `claude -p "your prompt"` |
-| Copilot one-shot (backup)             | `co "your prompt"`        |
-| Copilot interactive session (backup)  | `ico`                     |
+| What you want to do         | Command                   |
+| --------------------------- | ------------------------- |
+| Start a Claude Code session | `claude`                  |
+| Run a one-shot task         | `claude -p "your prompt"` |
 
 **Authenticate (one-time):**
 
-| Tool                                       | Command                                        |
-| ------------------------------------------ | ---------------------------------------------- |
-| Claude Code                                | `claude auth login`                            |
-| GitHub Copilot CLI (backup)                | `copilot login` (or `/login` inside a session) |
-| VS Code / JetBrains (Copilot autocomplete) | Sign in via the Copilot extension sidebar      |
-| glab (GitLab CLI)                          | `sjust gitlab-configure-glab`                  |
-| gh (GitHub CLI)                            | `gh auth login`                                |
+| Tool              | Command                       |
+| ----------------- | ----------------------------- |
+| Claude Code       | `claude auth login`           |
+| glab (GitLab CLI) | `sjust gitlab-configure-glab` |
+| gh (GitHub CLI)   | `gh auth login`               |
 
-All GitHub-based tools authenticate against **github.com** using your SparkFabrik organization account.
-
-The rest of this page covers how each tool works, when to use which, and the subscription policy.
+The rest of this page covers how each tool works and the subscription terms. For usage limits, the personal-use policy, and which harnesses are authorized, see [Claude Code usage and policy](/ai-development/claude-code-usage).
 
 ## Overview
 
@@ -59,28 +55,26 @@ To install or update a specific tool, use tags:
 
 ```bash
 sjust sparkdock-install-tags claude-code  # just Claude Code
-sjust sparkdock-install-tags copilot-cli  # just Copilot CLI
-sjust sparkdock-install-tags opencode     # just OpenCode
 sjust sparkdock-install-tags skills       # just shared skills
 sjust sparkdock-install-tags npm_packages # just npm packages (OpenSpec, etc.)
 ```
 
-### When to use what
+### Reactive and agentic modes
 
-AI coding tools operate in two modes: **reactive** (suggest code, wait for you to apply it) and **agentic** (plan, act, observe, adjust in a loop). Both are useful. The agentic mode (where the AI reads your codebase, forms a plan, executes it, runs tests, and course-corrects) is where the biggest productivity shift is happening.
+AI coding tools operate in two modes. **Reactive** tools suggest code and wait for you to apply it. **Agentic** tools plan, act, observe, and adjust in a loop: the AI reads your codebase, forms a plan, executes it, runs tests, and course-corrects.
 
-| Environment                                     | How it works                                                                                                                                 | Start with                                       |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| **Claude Code** (terminal, primary)             | Agentic: explores your codebase, plans, executes, tests, adjusts. Full tool use, skills, subagents, and MCP integrations.                    | `claude` to start a session                      |
-| **Claude Code** (VS Code / JetBrains extension) | Agentic: same capabilities as the terminal, with native IDE integration — inline diffs, plan review, @-mentions, multiple conversation tabs. | Install the Claude Code extension                |
-| **Copilot CLI** (terminal, backup)              | Agentic: same plan-act-observe loop. Available for teams that prefer it or need Copilot-specific features.                                   | `co "your prompt"` or `ico` for interactive      |
-| **Copilot** (VS Code / JetBrains, autocomplete) | Reactive: inline code completions as you type. Complements Claude Code — use both together.                                                  | Install the GitHub Copilot extension and sign in |
+Claude Code is agentic, and that loop is where the productivity shift happens.
 
-Use Claude Code (terminal or IDE extension) as your primary agent for implementation, debugging, and any task that benefits from an autonomous work loop. Copilot's inline autocomplete complements it with real-time code suggestions as you type.
+| Environment                         | How it works                                                                                                                        | Start with                        |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| **Claude Code** (terminal)          | Explores your codebase, plans, executes, tests, adjusts. Full tool use, skills, subagents, and Model Context Protocol integrations. | `claude` to start a session       |
+| **Claude Code** (VS Code extension) | The same capabilities as the terminal, with native editor integration: inline diffs, plan review, @-mentions, conversation tabs.    | Install the Claude Code extension |
+
+Use Claude Code as your primary agent for implementation, debugging, and any task that benefits from an autonomous work loop.
 
 ## Claude Code
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) is our primary AI coding assistant in the terminal. It is Anthropic's agentic coding tool that runs the full autonomous loop: reading your codebase, planning changes, executing them, running tests, and adjusting when things fail.
+[Claude Code](https://code.claude.com/docs) is Anthropic's agentic coding tool and our primary AI coding assistant. It runs the full autonomous loop: reading your codebase, planning changes, executing them, running tests, and adjusting when things fail.
 
 **Start a session:**
 
@@ -89,99 +83,50 @@ claude                         # start in the current directory
 claude -p "your prompt"        # one-shot mode (non-interactive, see warning below)
 ```
 
-> **Cost warning:** `claude -p` draws from a separate Agent SDK monthly credit, not your interactive usage limits. Once the credit is exhausted, usage is billed at API rates. See [Agent SDK and headless usage](#agent-sdk-and-headless-usage) below for details.
+> **Cost warning**: `claude -p` draws from a separate Agent SDK monthly credit, not your interactive usage limits. Once the credit is exhausted, usage is billed at API rates. See [Agent SDK and headless usage](#agent-sdk-and-headless-usage) below.
 
-Claude Code uses the current directory as project context. Type `/` for slash commands (including `/opsx:*` for OpenSpec workflows).
+Claude Code uses the current directory as project context. Type `/` for slash commands, including the `/opsx:*` commands for OpenSpec workflows.
 
 **What sets it apart:**
 
-- **Plan mode**: press `Shift+Tab` twice to enter plan mode. Claude explores and plans without making changes. Use this for anything touching multiple files.
-- **Full tool use**: reads, edits, creates files; runs shell commands; manages git
-- **Skills and agent profiles**: loads skills from `~/.agents/skills/` (system) and `.claude/skills/` (project); agent profiles from `.claude/agents/` (project) and `~/.claude/agents/` (user)
-- **Subagents**: delegate tasks to specialized agents that run in their own context window
-- **MCP integrations**: connect to external tools (GitLab, databases, design tools) via Model Context Protocol
-- **CLAUDE.md**: project-level instructions that compound over time — every mistake becomes a rule
-- **Permission controls**: sparkdock configures rules that require confirmation before destructive operations
+- **Plan mode.** Press `Shift+Tab` twice to enter plan mode. Claude explores and plans without making changes. Use this for anything touching multiple files.
+- **Full tool use.** Reads, edits, and creates files, runs shell commands, and manages git.
+- **Skills and agent profiles.** Loads skills from `~/.agents/skills/` (system) and `.claude/skills/` (project), and agent profiles from `.claude/agents/` (project) and `~/.claude/agents/` (user).
+- **Subagents.** Delegates tasks to specialized agents that run in their own context window.
+- **Model Context Protocol (MCP) integrations.** Connects to external tools such as GitLab, databases, and design tools.
+- **CLAUDE.md.** Project-level instructions that compound over time: every mistake becomes a rule.
+- **Permission controls.** The organization's managed policy defines which tools require confirmation and read-blocks secret files such as `.env`, `secrets/`, and private keys.
 
-**Configuration:** Claude Code reads project instructions from `CLAUDE.md` at the repository root and from `.claude/` directory. Global configuration lives in `~/.claude/`. See the [official documentation](https://docs.anthropic.com/en/docs/claude-code/overview) for details.
+**Configuration:** Claude Code reads project instructions from `CLAUDE.md` at the repository root and from the `.claude/` directory. Global configuration lives in `~/.claude/`. The organization also pushes managed settings that take precedence over both, described in [Org-managed settings](/ai-development/claude-code-usage#org-managed-settings).
 
 ### IDE integration
 
-Claude Code also runs natively inside your IDE, providing the same agentic capabilities with a graphical interface. This is **separate from** Copilot's inline autocomplete — they complement each other:
-
-- **Claude Code extension** = agentic coding (plan, execute, review diffs, multi-step tasks)
-- **Copilot extension** = reactive inline completions (code suggestions as you type)
-
-You can use both simultaneously.
-
-#### VS Code
-
-Install the [Claude Code extension for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) (requires VS Code 1.98.0+).
+Claude Code runs natively inside VS Code, providing the same agentic capabilities with a graphical interface. Install the [Claude Code extension for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) from the marketplace.
 
 Key features:
 
-- **Inline diffs**: Claude shows side-by-side comparisons of proposed changes; accept, reject, or edit before applying
-- **Plan review**: in Plan mode, Claude opens the plan as a full markdown document where you can add inline comments before execution
-- **@-mentions**: reference files, folders, or line ranges (`@src/auth.ts#5-10`) for precise context
-- **Multiple conversations**: open sessions in separate tabs or windows for parallel work
-- **Session history**: resume past conversations, including remote sessions from claude.ai
-- **Keyboard shortcuts**: `Cmd+Esc` / `Ctrl+Esc` to toggle focus, `Option+K` / `Alt+K` to insert @-mention references
+- **Inline diffs.** Claude shows side-by-side comparisons of proposed changes. Accept, reject, or edit before applying.
+- **Plan review.** In plan mode, Claude opens the plan as a full markdown document where you can add inline comments before execution.
+- **@-mentions.** Reference files, folders, or line ranges (`@src/auth.ts#5-10`) for precise context.
+- **Multiple conversations.** Open sessions in separate tabs or windows for parallel work.
+- **Session history.** Resume past conversations, including remote sessions.
+- **Keyboard shortcuts.** `Cmd+Esc` or `Ctrl+Esc` toggles focus, `Option+K` or `Alt+K` inserts an @-mention reference.
 
-Open Claude via the Spark icon in the editor toolbar, the Activity Bar, or the Command Palette (`Cmd+Shift+P` → "Claude Code").
+Open Claude via the icon in the editor toolbar, the Activity Bar, or the Command Palette (`Cmd+Shift+P`, then "Claude Code").
 
-For the full reference, see the [Claude Code VS Code docs](https://code.claude.com/docs/en/vs-code).
+For the full reference, see the [Claude Code VS Code documentation](https://code.claude.com/docs/en/vs-code).
 
-#### JetBrains (beta)
+## Exceptions: Copilot and OpenCode
 
-Install the [Claude Code plugin for JetBrains](https://plugins.jetbrains.com/plugin/27310-claude-code-beta-) (IntelliJ IDEA, WebStorm, PyCharm, GoLand, and other IntelliJ-based IDEs).
+GitHub Copilot and OpenCode are not part of the standard setup. Copilot seats are granted on demand, case by case, for a few specific needs, and OpenCode is authorized only as a Copilot-backed harness for people who hold such a seat.
 
-The plugin is currently in **beta**. It provides the same agentic workflow within the JetBrains IDE family.
+Both exceptions, and the reasons behind them, are defined in [Support boundary](/ai-development/claude-code-usage#support-boundary). Read that section before assuming either tool is available to you.
 
-## GitHub Copilot (secondary)
-
-GitHub Copilot remains available as a secondary tool. Its primary value is **IDE inline autocomplete** — the real-time code suggestions that appear as you type in VS Code or JetBrains. The Copilot CLI is available as a backup terminal agent for teams that prefer it.
-
-### IDE autocomplete
-
-GitHub Copilot runs as an extension in VS Code and JetBrains IDEs, providing inline completions and a chat panel. Install it from your IDE's extension marketplace and sign in with your GitHub account. This continues to work alongside Claude Code — use Claude Code for agentic tasks in the terminal, and Copilot's inline suggestions as you type in your editor.
-
-### Copilot CLI (backup)
-
-[GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) is available for teams that still need it. Sparkdock installs it and configures shell aliases.
-
-```bash
-co "your prompt"        # one-shot mode
-ico                     # interactive mode
-ico --model gemini-3-pro  # start with a specific model
-```
-
-Skills and slash commands work in both the terminal CLI and the IDE extension.
-
-## OpenCode (backup)
-
-[OpenCode](https://opencode.ai) is an open-source, model-agnostic terminal coding agent. It is available as a backup option for teams that need model-agnostic flexibility or are still transitioning to Claude Code.
-
-**Start a session:**
-
-```bash
-c                          # start in the current directory
-c --agent the-architect    # start with a specific agent profile
-```
-
-OpenCode uses the current directory as project context. Press `Tab` to switch agent profiles, type `/` for slash commands (including `/opsx:*` for OpenSpec workflows).
-
-**What sets it apart:**
-
-- **Model-agnostic**: works with Claude, GPT, Gemini, and others; no vendor lock-in
-- **Full tool use**: reads, edits, creates files; runs shell commands; manages git
-- **Skills and agent profiles**: loads from `~/.agents/skills/` (system), `.opencode/skills/` (project), and `~/.config/opencode/agents/` (agent profiles)
-- **Permission controls**: sparkdock configures rules that require confirmation before destructive operations
-
-**Configuration:** sparkdock installs the config at `~/.config/opencode/opencode.json`. You generally don't need to edit it.
+Sparkdock still provisions both tools, so they install on every workstation. Installation is not authorization: use them only within the boundary above.
 
 ## OpenSpec
 
-[OpenSpec](https://openspec.dev) is a framework for capturing requirements, design decisions, and implementation tasks as structured artifacts before and during AI-assisted development. It's installed as an npm package by sparkdock. Verify with:
+[OpenSpec](https://openspec.dev) is a framework for capturing requirements, design decisions, and implementation tasks as structured artifacts before and during AI-assisted development. Sparkdock installs it as an npm package. Verify with:
 
 ```bash
 openspec --version
@@ -191,39 +136,37 @@ OpenSpec is covered in detail on its own page: **[Spec-Driven Development](/ai-d
 
 ## Other CLI tools
 
-Sparkdock also installs CLI tools that aren't AI-specific but that the coding agents use via [skills](/ai-development/skills-and-agents):
+Sparkdock also installs CLI tools that are not AI-specific but that Claude Code uses via [skills](/ai-development/skills-and-agents):
 
 | Tool                                          | What it is                                           | Setup                                         |
 | --------------------------------------------- | ---------------------------------------------------- | --------------------------------------------- |
 | **[glab](https://gitlab.com/gitlab-org/cli)** | GitLab CLI: issues, merge requests, CI/CD pipelines  | `sjust gitlab-configure-glab` (one-time auth) |
 | **[gh](https://cli.github.com)**              | GitHub CLI: issues, pull requests, actions, releases | `gh auth login` (one-time auth)               |
 
-Both tools work standalone in your terminal and are also used by Claude Code and other agents through skills (e.g., the [glab skill](https://github.com/sparkfabrik/sf-awesome-copilot/tree/main/skills/system/glab) lets the AI fetch issue details, read MR discussions, and check pipelines on your behalf).
+Both tools work standalone in your terminal and are also used by Claude Code through skills. The glab skill, for example, lets the agent fetch issue details, read merge request discussions, and check pipelines on your behalf.
 
 ## Installation and updates
 
-Everything is managed by sparkdock. Here are the commands you'll use most:
+Everything is managed by sparkdock. These are the commands you will use most:
 
-| Command                              | What it does                                            |
-| ------------------------------------ | ------------------------------------------------------- |
-| `sjust sparkdock-upgrade`            | Full provisioning: installs/updates all tools           |
-| `sjust sparkdock-install-tags <tag>` | Install/update specific tools by tag                    |
-| `sjust sf-harness-sync`              | Sync shared skills and agent profiles from upstream     |
-| `sjust sf-harness-status`            | Show installed skills, agent profiles, and their status |
+| Command                              | What it does                                             |
+| ------------------------------------ | -------------------------------------------------------- |
+| `sjust sparkdock-upgrade`            | Full provisioning: installs and updates all tools        |
+| `sjust sparkdock-install-tags <tag>` | Installs or updates specific tools by tag                |
+| `sjust sf-harness-sync`              | Syncs shared skills and agent profiles from upstream     |
+| `sjust sf-harness-status`            | Shows installed skills, agent profiles, and their status |
 
 If a tool is missing or outdated, `sjust sparkdock-upgrade` is always the safe default.
 
 ### What sparkdock installs
 
-| Package            | Source                              | Tag            |
-| ------------------ | ----------------------------------- | -------------- |
-| Claude Code        | npm (`@anthropic-ai/claude-code`)   | `claude-code`  |
-| GitHub Copilot CLI | Homebrew Cask (`copilot-cli`)       | `copilot-cli`  |
-| OpenCode           | Homebrew (`anomalyco/tap/opencode`) | `opencode`     |
-| glab               | Homebrew                            | `glab`         |
-| OpenSpec           | npm (`@fission-ai/openspec`)        | `npm_packages` |
+| Package     | Source                            | Tag            |
+| ----------- | --------------------------------- | -------------- |
+| Claude Code | npm (`@anthropic-ai/claude-code`) | `claude-code`  |
+| glab        | Homebrew                          | `glab`         |
+| OpenSpec    | npm (`@fission-ai/openspec`)      | `npm_packages` |
 
-Sparkdock also configures shell aliases, zsh completions, and permission rules for all agents.
+Sparkdock also configures shell aliases, zsh completions, and permission rules.
 
 ## Authentication
 
@@ -235,43 +178,11 @@ Run `claude auth login` from your terminal:
 claude auth login
 ```
 
-This opens your browser for authentication. Claude Code uses your Anthropic account linked to the SparkFabrik organization. The token is stored locally.
-
-For the full reference, see the official docs: [Claude Code authentication](https://docs.anthropic.com/en/docs/claude-code/overview).
-
-### GitHub Copilot CLI
-
-Copilot CLI has its own authentication, separate from the `gh` CLI. Run `copilot login` from your terminal (or `/login` inside an active session):
-
-```bash
-copilot login
-```
-
-This opens your browser at `github.com/login/device` where you enter the one-time code displayed in the terminal. Select **GitHub.com**, authorize, and you're set. The token is stored in your OS keychain under the service name `copilot-cli`.
-
-> If you've already authenticated with `gh auth login`, Copilot CLI can use that token as a **fallback**. But we recommend running `copilot login` explicitly so Copilot CLI has its own stored credential.
-
-For the full reference, see the official docs: [Authenticating GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli).
-
-### GitHub Copilot in VS Code / JetBrains
-
-Sign in through the Copilot extension sidebar. It opens the same GitHub OAuth flow in your browser. Once authorized, the extension stays authenticated.
-
-### OpenCode (backup)
-
-Open an OpenCode session (`c`), then run the `/connect` command:
-
-```
-/connect
-```
-
-Select **GitHub Copilot** from the provider list. OpenCode gives you a device code and a link to `github.com/login/device`. Enter the code, authorize, done.
-
-For the full reference, see the OpenCode docs: [GitHub Copilot provider](https://opencode.ai/docs/providers/#github-copilot).
+This opens your browser for authentication. Claude Code uses your Anthropic account linked to the SparkFabrik organization, and signing in applies the organization's managed policy automatically. The token is stored locally.
 
 ### glab (GitLab CLI)
 
-glab authenticates against **GitLab**, not GitHub. Run:
+glab authenticates against GitLab, not GitHub. Run:
 
 ```bash
 sjust gitlab-configure-glab
@@ -285,84 +196,63 @@ This is a one-time setup handled by sparkdock.
 gh auth login
 ```
 
-Select **GitHub.com**, authenticate via browser. This is also the fallback credential for Copilot CLI if `copilot login` hasn't been run.
+Select **GitHub.com** and authenticate via browser.
 
 ## Claude Code subscription
 
 Claude Code is provided through the SparkFabrik organization's Anthropic plan. Interactive usage (Claude Code sessions, Claude Cowork, Claude chat) consumes your plan's usage limits.
 
-> For interactive usage limits, the personal-use policy, org-managed settings, and multi-account guidance, see **[Claude Code usage & policy](/ai-development/claude-code-usage)**.
+> For interactive usage limits, the personal-use policy, org-managed settings, and multi-account guidance, see **[Claude Code usage and policy](/ai-development/claude-code-usage)**.
 
 ### Agent SDK and headless usage
 
-Starting **June 15, 2026**, `claude -p` (headless/one-shot) and Agent SDK usage no longer count toward interactive usage limits. These get a **separate monthly credit** that refreshes with the billing cycle:
+Headless usage (`claude -p`) and Agent SDK usage do not count toward interactive usage limits. They draw on a **separate monthly credit** that refreshes with the billing cycle, sized by plan.
 
-| Plan                                  | Monthly credit |
-| ------------------------------------- | -------------- |
-| Pro                                   | $20            |
-| Max 5x                                | $100           |
-| Max 20x                               | $200           |
-| Team (Standard seats)                 | $20            |
-| Team (Premium seats)                  | $100           |
-| Enterprise (usage-based)              | $20            |
-| Enterprise (seat-based Premium seats) | $200           |
+This means your interactive Claude Code sessions and your continuous integration or automation pipelines have independent budgets. Once the Agent SDK credit is exhausted, additional usage is billed at standard API rates if usage credits are enabled, and otherwise requests stop until the next billing cycle.
 
-This means your interactive Claude Code sessions and your CI/automation (`claude -p`) pipelines have independent budgets. Once the Agent SDK credit is exhausted, additional usage is billed at standard API rates (if usage credits are enabled), otherwise requests stop until the next billing cycle.
+For the credit amount that applies to your plan, see the official Anthropic article below rather than a figure copied here.
 
 **References:**
 
-- [Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) (official Anthropic support article)
-- [What Anthropic's New Claude Billing Means for Zed Users](https://zed.dev/blog/anthropic-subscription-changes) (Zed blog, practical impact analysis)
-- [Anthropic Claude pricing changes](https://www.axios.com/2026/05/14/anthropic-claude-price-openai-tokens) (Axios coverage)
+- [Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) (official Anthropic support article, including the per-plan credit amounts)
+- [Manage costs effectively](https://code.claude.com/docs/en/costs) (model selection, `/usage`, reducing token use)
 
-## GitHub Copilot subscription policy
+## GitHub Copilot seats
 
-The GitHub Copilot subscription is maintained primarily for **IDE inline autocomplete** and as a backup terminal agent. Claude Code is our primary agentic coding tool.
+A GitHub Copilot seat is not part of the standard developer setup. Seats are granted **on demand, case by case**, for a few specific needs. Ask the platform team if you think you have one.
 
-### Eligibility
-
-All employees with access to GitHub can use GitHub Copilot. You should receive a subscription during onboarding.
+If you hold a seat, the terms below apply.
 
 ### Usage policy
 
-1. Employees are encouraged to use AI suggestions but **must use their own judgment** when applying them. Always review suggested code and understand it before implementing it. The name is *Co*pilot, not *Auto*pilot.
+1. Use your own judgment when applying AI suggestions. Always review suggested code and understand it before shipping it. The name is _Co_pilot, not _Auto_pilot.
 
-2. Employees must comply with all company policies when using GitHub Copilot. Non-compliance is the employee's responsibility.
+2. Comply with all company policies when using GitHub Copilot. Non-compliance is the employee's responsibility.
 
-3. The service is regulated by the [GitHub Terms for Additional Products and Features](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot) and the [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement). Code snippets are transmitted in real-time for suggestions but are not retained by default. For details on data handling, see the [GitHub Copilot Trust Center](https://copilot.github.trust.page/). It is the employer's responsibility to verify that these terms are acceptable for their specific use case; if in doubt, ask your team lead or manager.
-
-4. This policy is reviewed periodically and updated as needed.
+3. The service is regulated by the [GitHub Terms for Additional Products and Features](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot) and the [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement). Code snippets are transmitted in real time for suggestions but are not retained by default. For details on data handling, see the [GitHub Copilot Trust Center](https://copilot.github.trust.page/). It is the employer's responsibility to verify that these terms are acceptable for a specific use case. If in doubt, ask your team lead or manager.
 
 ### Personal use
 
-GitHub attaches the Copilot subscription to your personal GitHub account. When the organization seat is assigned, any existing personal subscription is automatically cancelled. We recognize this means the tools you use for work are the same tools available on your personal projects.
+GitHub attaches the Copilot subscription to your personal GitHub account. When the organization seat is assigned, any existing personal subscription is automatically cancelled. This means the tool you use for work is the same tool available on your personal projects.
 
-Here is what is and isn't covered:
+Here is what is and is not covered:
 
-- **Open source and community contributions: encouraged.** Contributing to open source projects, building community tools, and participating in hackathons all build skills that benefit you and the company.
+- **Open source and community contributions: encouraged.** Contributing to open source projects, building community tools, and taking part in hackathons all build skills that benefit you and the company.
 - **Personal non-commercial projects: allowed.** Learning new technologies, hobby projects, and personal tools are fine, within the guidelines below.
-- **Personal commercial projects: not covered.** Freelance work, side businesses, SaaS products, and paid consulting deliverables should not use the company-provided subscription.
+- **Personal commercial projects: not covered.** Freelance work, side businesses, SaaS products, and paid consulting deliverables must not use the company-provided seat.
 - **Projects that compete with the company: not allowed.** Personal projects must not compete with SparkFabrik's products, services, or business areas.
 
 A few guidelines:
 
 1. **Work takes priority.** Premium requests are metered and have a cost. If your usage is unusually high, we may ask about it.
-2. **Keep company and personal work separate.** Personal projects must not include, reuse, or be derived from company code, proprietary logic, or confidential information.
-3. **Your personal projects are yours.** The company makes no intellectual property claim on code you write for personal or open source projects, provided it is developed outside working hours and is not related to the company's business.
-4. **This is trust-based.** We'd rather give clear boundaries than build surveillance. If costs become unsustainable, we'll revisit the policy with transparency.
+2. **Keep company and personal work separate.** Personal projects must not include, reuse, or derive from company code, proprietary logic, or confidential information.
+3. **Your personal projects are yours.** The company makes no intellectual property claim on code you write for personal or open source projects, provided it is developed outside working hours and is unrelated to the company's business.
+4. **This is trust-based.** We would rather give clear boundaries than build surveillance. If costs become unsustainable, we will revisit the policy with transparency.
 
-If you're unsure whether a specific use case qualifies, ask your manager.
+If you are unsure whether a specific use case qualifies, ask your manager.
 
-### Requesting a subscription
-
-If you weren't granted a subscription during onboarding:
-
-1. On the [GitHub Copilot settings page](https://github.com/settings/copilot), locate **Get Copilot from an organization**
-2. Use **Ask admin for access** on the **SparkFabrik** organization
-3. Confirm with an HR representative via the `#support-hr` channel
-
-The subscription is through our GitHub Organization. Any existing personal Copilot subscription on the same account will be automatically cancelled and refunded by GitHub.
+> The equivalent policy for Claude Code, which has different constraints because the usage budget is shared and finite, lives in [Personal use under limits](/ai-development/claude-code-usage#personal-use-under-limits).
 
 ### Refunding a previously purchased subscription
 
-If you already purchased a personal GitHub Copilot subscription, GitHub will refund the unused portion when the Organization subscription is attached. You can request a refund for the partial paid subscription using the company's employee refund platform, only if it was previously approved as a company expense.
+If you already purchased a personal GitHub Copilot subscription, GitHub refunds the unused portion when the organization seat is attached. You can request a refund for the partial paid subscription through the company's employee refund platform, only if it was previously approved as a company expense.

--- a/content/procedures/assessing-core-skills.md
+++ b/content/procedures/assessing-core-skills.md
@@ -79,7 +79,7 @@ Everyone should have a basic understanding of:
 
 #### AI Coding Tools
 
-That's a "bonus track". Developers are the most impacted by the usage of AI coding tools, so ask if they know what Claude Code (our primary agent) and GitHub Copilot (IDE autocomplete) are and if they have experience with agentic coding workflows.
+That's a "bonus track". Developers are the most impacted by the usage of AI coding tools, so ask if they know what Claude Code (the agent we use) is and if they have experience with agentic coding workflows.
 
 ### DevOps
 

--- a/content/procedures/employee-offboarding.md
+++ b/content/procedures/employee-offboarding.md
@@ -39,7 +39,7 @@ It outlines the tasks required to complete the offboarding process, alongside th
 * Admin verifies the status of the returned device in Apple Business Manager and updates it accordingly.
 * HR informs the clients to deactivate any accounts associated with their systems, if applicable.
 * HR and Admin must revoke any other account (if any) on SparkFabrik-controlled services such as Miro, Trello, Smart Retro, etc.
-* Tech and Admin must revoke licenses for JetBrains software and other softwares, if applicable.
+* Tech and Admin must revoke the AI tooling access (the Anthropic organization seat, and a GitHub Copilot seat if one was granted) and any other software license, if applicable.
 * Operations must remove the resigned employee from all the projects and teams-related mail groups (`*-team@sparkfabrik.com`)
 
 

--- a/content/procedures/employee-onboarding.md
+++ b/content/procedures/employee-onboarding.md
@@ -55,7 +55,7 @@ The employee must, with the help of an HR representative:
 * Duly sign in and check their ability to access every service
 * If they are a developer, ensure they are authenticated on GCP with their SparkFabrik account
 * If they are a Drupal developer, make sure [they can build FireStarter-based projects](/guides/local-development-environment-configuration#configure-firestarter-builds)
-* If they are a developer, add the user to the `Copilot members` team on GitHub (for IDE autocomplete) and help them [set up AI development tools](/ai-development/tools-and-setup) (Claude Code as primary)
+* If they are a developer, help them [set up AI development tools](/ai-development/tools-and-setup) and point them at the [usage limits and policy](/ai-development/claude-code-usage). A GitHub Copilot seat is not part of the standard setup: grant one only on request, case by case
 * Activate two-factor authentication on Gitlab
 * Generate an SSH key and add it among the available keys for their Gitlab account
 * If applicable, [set up AI development tools](/ai-development/tools-and-setup) and [review the AI development overview](/ai-development/overview)

--- a/content/resources/training-resources.md
+++ b/content/resources/training-resources.md
@@ -115,7 +115,7 @@ All the training material in this section is public and can be freely accessed.
 |-------------------|--------------------------------------------------------------------------------|
 | **Documentation** | [Claude Code overview](https://docs.anthropic.com/en/docs/claude-code/overview) |
 |                   | [SparkFabrik's AI development tools and setup](/ai-development/tools-and-setup) |
-|                   | [Quickstart for GitHub Copilot](https://docs.github.com/en/copilot/quickstart) (IDE autocomplete) |
+|                   | [SparkFabrik's Claude Code usage limits and policy](/ai-development/claude-code-usage) |
 
 ## DevOps
 

--- a/content/working-at-sparkfabrik/core-skills.md
+++ b/content/working-at-sparkfabrik/core-skills.md
@@ -36,7 +36,7 @@ Anyway, during the [very first days of onboarding](/procedures/employee-onboardi
 |---|---|
 | **YAML** | _Yet Another Markup Language_, this declarative, structured JSON alternative is easy to read and write for humans and easy to parse and abstract for a machine. These qualities made it almost ubiquitous. It's syntax is very simple but powerful. |
 | **Git** | Git is the industry standard CVS and it's at the base of every project we develop. Git is highly intertwined with our automation, so it's vital to understand how it works, and how the various aspects of the workflow impact our delivery. |
-| **GitHub Copilot** | A context-aware, AI-based tool that helps writing code faster. When used correctly, it allows to optimize repetitive tasks and quickly create prototypes and blueprints. |
+| **Claude Code** | The agentic AI coding assistant we use. It reads the codebase, plans a change, executes it and runs the tests, so knowing how to direct it, review what it produces and work within its usage limits is part of the job. |
 
 | DevOps | |
 |---|---|


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #316

Two decisions were only partially reflected in the playbook, so the AI section contradicted itself in public. Claude Code is the AI coding tool we use, with GitHub Copilot and OpenCode reserved for specific agreed cases, and VS Code is the only supported editor.

`content/ai-development/claude-code-usage.md` already stated the current rule. This change makes it the single owning page for the exception and brings the other eleven pages in line, so no page restates the rule and none contradicts it.

## The contradictions this removes

- `overview.md` said "GitHub Copilot CLI is our primary terminal assistant. OpenCode is currently experimental", and Claude Code was absent from its CLI tools table. That page is the section landing page.
- `tools-and-setup.md` said "All employees with access to GitHub can use GitHub Copilot. You should receive a subscription during onboarding."
- `security.md` documented the OpenCode permission system as the only agent permission model, and its data-handling table had no Claude Code column.
- `employee-onboarding.md` provisioned a `Copilot members` team seat as a default onboarding step.

## Defects fixed along the way

**The metadata block on `tools-and-setup.md` was corrupted.** It opened with `/_` instead of `/*`, so Raneto parsed neither the description nor the sort order. A formatter run caused it, which is the failure mode `CLAUDE.md` warns about. It is fixed in its own commit, and the local render now places the page correctly and emits its description.

**Facts were verified against the sources rather than carried over.** Several statements turned out to be wrong:

- Claude Code permission rules come from the organization managed policy. Sparkdock configures rules only for OpenCode, so the old claim was misattributed.
- The generated OpenSpec tree came from actually running `openspec init --tools claude`. The committed tree described `.opencode/` and `.github/` branches that the command does not produce, and the command list was missing `/opsx:propose`.
- The shared catalog no longer has `agents/system/` or per-tool subdirectories, and system skills are a category of many rather than the single `glab` entry the page listed.

**Two figures that drift were removed**, per the evergreen rule: the VS Code minimum version and the per-plan Agent SDK credit table now point at the upstream source instead of hardcoding numbers.

**Offboarding now revokes the Anthropic organization seat.** The checklist revoked JetBrains licenses but never the AI seat that actually matters.

## Out of scope

The PHPStorm and Xdebug walkthrough in `content/guides/local-development-environment-usage.md` is untouched. Replacing it needs a tested VS Code `launch.json` equivalent, which is its own task.

The skill category system (`sf-harness-category`) is only mentioned, not documented. It deserves its own page.

## Verification

- `make check` reports 24 invalid links, the same count as `master`. None of them sits on a line this branch touches, and the two that look new (`git-workflow.md`, `local-development-environment-configuration.md`) are pre-existing and 404 on `master` too. Total links checked dropped from 574 to 567 because Copilot and OpenCode links were removed.
- Every metadata block was re-checked after running Prettier, since Prettier is what broke one in the first place.
- Rendered locally: all eight AI pages return their title, the section index orders them exactly as their `Sort` values declare, no raw metadata leaks into any body, and every remaining "primary" claim refers to Claude Code.
- Formatter churn was reverted in the five policy pages where Prettier renormalized bullets across the whole file, so each shows a one-line diff.

> Merging deploys to production. Worth a look at the AI section pages afterwards.